### PR TITLE
Encrypt OAuth tokens at rest

### DIFF
--- a/src/utils/secure-token-storage.ts
+++ b/src/utils/secure-token-storage.ts
@@ -1,0 +1,151 @@
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync, createHash } from 'crypto';
+import { hostname, userInfo } from 'os';
+
+/**
+ * Encrypted token storage format
+ */
+export interface EncryptedData {
+  version: number;
+  encrypted: string;
+}
+
+/**
+ * SecureTokenStorage provides encryption-at-rest for sensitive data like OAuth tokens.
+ *
+ * Uses AES-256-GCM encryption with a key derived from machine-specific identifiers.
+ * This ensures tokens are only decryptable on the same machine by the same user.
+ */
+export class SecureTokenStorage {
+  private static readonly ALGORITHM = 'aes-256-gcm';
+  private static readonly KEY_LENGTH = 32;
+  private static readonly IV_LENGTH = 16;
+  private static readonly AUTH_TAG_LENGTH = 16;
+  private static readonly VERSION = 1;
+  private static readonly SALT = 'shippost-token-encryption-v1';
+
+  /**
+   * Get a machine-specific encryption key.
+   *
+   * The key is derived from machine and user identifiers, making tokens
+   * only decryptable on the same machine by the same user.
+   */
+  private getEncryptionKey(): Buffer {
+    // Combine multiple machine/user identifiers for key derivation
+    // This ensures tokens can't be decrypted if the file is copied to another machine
+    const machineId = this.getMachineIdentifier();
+    return scryptSync(machineId, SecureTokenStorage.SALT, SecureTokenStorage.KEY_LENGTH);
+  }
+
+  /**
+   * Generate a machine-specific identifier for key derivation.
+   *
+   * Uses a combination of:
+   * - Hostname
+   * - Username
+   * - Home directory
+   *
+   * This isn't meant to be unguessable - it's defense in depth.
+   * The primary security comes from file permissions (0o600).
+   */
+  private getMachineIdentifier(): string {
+    const user = userInfo();
+    const components = [
+      hostname(),
+      user.username,
+      user.homedir,
+      // Add a constant to make the key unique to this application
+      'shippost-oauth-v1',
+    ];
+
+    // Hash the components to get a consistent length identifier
+    const hash = createHash('sha256');
+    hash.update(components.join('|'));
+    return hash.digest('hex');
+  }
+
+  /**
+   * Encrypt data using AES-256-GCM.
+   *
+   * @param data - The data object to encrypt
+   * @returns Encrypted data wrapper with version info
+   */
+  encrypt<T>(data: T): EncryptedData {
+    const key = this.getEncryptionKey();
+    const iv = randomBytes(SecureTokenStorage.IV_LENGTH);
+    const cipher = createCipheriv(SecureTokenStorage.ALGORITHM, key, iv);
+
+    const plaintext = JSON.stringify(data);
+    const encrypted = Buffer.concat([
+      cipher.update(plaintext, 'utf8'),
+      cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+
+    // Combine IV + auth tag + ciphertext into a single base64 string
+    const combined = Buffer.concat([iv, authTag, encrypted]);
+
+    return {
+      version: SecureTokenStorage.VERSION,
+      encrypted: combined.toString('base64'),
+    };
+  }
+
+  /**
+   * Decrypt data that was encrypted with encrypt().
+   *
+   * @param encryptedData - The encrypted data wrapper
+   * @returns The decrypted data object, or null if decryption fails
+   */
+  decrypt<T>(encryptedData: EncryptedData): T | null {
+    try {
+      if (encryptedData.version !== SecureTokenStorage.VERSION) {
+        // Unknown version - can't decrypt
+        return null;
+      }
+
+      const key = this.getEncryptionKey();
+      const combined = Buffer.from(encryptedData.encrypted, 'base64');
+
+      // Extract IV, auth tag, and ciphertext
+      const iv = combined.subarray(0, SecureTokenStorage.IV_LENGTH);
+      const authTag = combined.subarray(
+        SecureTokenStorage.IV_LENGTH,
+        SecureTokenStorage.IV_LENGTH + SecureTokenStorage.AUTH_TAG_LENGTH
+      );
+      const ciphertext = combined.subarray(
+        SecureTokenStorage.IV_LENGTH + SecureTokenStorage.AUTH_TAG_LENGTH
+      );
+
+      const decipher = createDecipheriv(SecureTokenStorage.ALGORITHM, key, iv);
+      decipher.setAuthTag(authTag);
+
+      const decrypted = Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+      ]);
+
+      return JSON.parse(decrypted.toString('utf8')) as T;
+    } catch {
+      // Decryption failed - likely wrong key (different machine/user)
+      // or corrupted data
+      return null;
+    }
+  }
+
+  /**
+   * Check if data looks like it's in encrypted format.
+   *
+   * @param data - The data to check
+   * @returns true if the data appears to be encrypted
+   */
+  isEncrypted(data: unknown): data is EncryptedData {
+    return (
+      typeof data === 'object' &&
+      data !== null &&
+      'version' in data &&
+      'encrypted' in data &&
+      typeof (data as EncryptedData).version === 'number' &&
+      typeof (data as EncryptedData).encrypted === 'string'
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Implement AES-256-GCM encryption for OAuth tokens stored on disk to address security vulnerability #31. Tokens are now encrypted using a machine-specific key derived from hostname, username, and home directory, ensuring they're only decryptable on the same machine by the same user. Added `SecureTokenStorage` utility class with automatic migration from plaintext (legacy) to encrypted format.

**Key changes:**
- New `SecureTokenStorage` class with `encrypt()` and `decrypt()` methods using AES-256-GCM
- Machine-specific key derivation via `scryptSync()` prevents token portability across machines
- Automatic migration of legacy plaintext tokens to encrypted format on load
- Maintains file permissions (`0o600`) for defense in depth
- Graceful handling of decryption failures with user-friendly warnings 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/bbd158cc-a367-415e-a6f0-7d5f242e2ee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/agents"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?theme=light&v=11" height="28"></picture></a> 