### PR TITLE
ship ui: local web app for the full content pipeline

### DIFF
--- a/src/commands/blog.ts
+++ b/src/commands/blog.ts
@@ -358,12 +358,14 @@ ${threadContent}
 Total engagement: ${totalEngagement} (likes + replies + retweets combined)
 
 Create a blog post that:
-1. Expands on the ideas from the ${isThread ? 'thread' : 'tweet'}
-2. Adds context, examples, or deeper explanation
+1. Makes ONE argument — the strongest point from the ${isThread ? 'thread' : 'tweet'} — and cuts everything that does not support it
+2. Adds just enough context or example to ground that single argument
 3. Maintains the voice and tone of the original
-4. Is 500-1200 words
+4. Is 250-450 words (hard cap 500), 3-5 short paragraphs, with NO ## section headers — the post is itself one section
 5. Has a compelling title
-6. IMPORTANT: Include {{EMBED_PLACEHOLDER}} markers where you want X post embeds to appear (3-5 embeds total, spread throughout the post). The first embed should appear early to show the original inspiration.
+6. IMPORTANT: Include {{EMBED_PLACEHOLDER}} markers where you want X post embeds to appear (1-2 embeds total). The first embed should appear early to show the original inspiration.
+7. Uses NO em dashes (—) anywhere, including the title. Use a comma, colon, or period instead. Site lint rejects essays with em dashes.
+8. Uses NO stock AI phrasings: never "the thing nobody says out loud" (or any nobody/no one ... out loud variant), never "saying the quiet part out loud".
 
 Format your response as:
 
@@ -450,14 +452,23 @@ function generateFilename(title: string, frameworkConfig: FrameworkConfig, useMd
   return `${slug}.${ext}`;
 }
 
+// Site rule: generated essays must contain zero em dashes (rywalker.com lint
+// allows at most one per essay, reserved for human edits). The prompt forbids
+// them; this is the mechanical backstop.
+function stripEmDashes(s: string): string {
+  return s.replace(/[ \t]*—[ \t]*/g, ', ');
+}
+
 function parseBlogResponse(response: string): { title: string; content: string } {
   const titleMatch = response.match(/TITLE:\s*(.+)/i);
-  const title = titleMatch ? titleMatch[1].trim() : 'Untitled';
+  const title = titleMatch ? stripEmDashes(titleMatch[1].trim()) : 'Untitled';
 
   // Remove the TITLE line and get the rest as content
-  const content = response
-    .replace(/TITLE:\s*.+/i, '')
-    .trim();
+  const content = stripEmDashes(
+    response
+      .replace(/TITLE:\s*.+/i, '')
+      .trim()
+  );
 
   return { title, content };
 }

--- a/src/commands/granola-sync.ts
+++ b/src/commands/granola-sync.ts
@@ -10,11 +10,13 @@ interface GranolaSyncOptions {
   force?: boolean;
 }
 
-interface GranolaDocument {
+export interface GranolaDocument {
   id: string;
   title: string;
   created_at: string;
   transcribe?: boolean;
+  people?: { attendees?: { name?: string; email?: string }[] };
+  google_calendar_event?: { attendees?: { displayName?: string; email?: string }[] };
 }
 
 interface GranolaSyncState {
@@ -37,7 +39,7 @@ const GRANOLA_API_HEADERS = {
 // (cache-v6.json, granola.db) is no longer plaintext-readable. We instead
 // pull the still-readable refresh_token from the leftover supabase.json,
 // mint a fresh access_token, and hit the API directly.
-function loadGranolaRefreshToken(): string {
+export function loadGranolaRefreshToken(): string {
   const authPath = join(GRANOLA_DIR, 'supabase.json');
   if (!existsSync(authPath)) {
     throw new Error('Granola credentials not found. Make sure the Granola app is installed and you are logged in.');
@@ -58,7 +60,7 @@ function loadGranolaRefreshToken(): string {
   return tokens.refresh_token;
 }
 
-async function refreshAccessToken(refreshToken: string): Promise<string> {
+export async function refreshAccessToken(refreshToken: string): Promise<string> {
   const response = await fetch('https://api.granola.ai/v1/refresh-access-token', {
     method: 'POST',
     headers: GRANOLA_API_HEADERS,
@@ -79,7 +81,7 @@ async function refreshAccessToken(refreshToken: string): Promise<string> {
   return data.access_token;
 }
 
-async function fetchGranolaDocuments(accessToken: string): Promise<Record<string, GranolaDocument>> {
+export async function fetchGranolaDocuments(accessToken: string): Promise<Record<string, GranolaDocument>> {
   const PAGE_SIZE = 1000;
   const documents: Record<string, GranolaDocument> = {};
   let offset = 0;

--- a/src/commands/reply.ts
+++ b/src/commands/reply.ts
@@ -15,12 +15,35 @@ import { openInEditor, getEditorDisplayName } from '../utils/editor.js';
 
 const SKIP_CACHE_FILE = '.shippost-skipped-tweets.json';
 const SKIP_CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
+const FEED_SEEN_FILE = '.shippost-feed-seen.json';
+
+/** Accounts observed in Ry's home timeline, authorId → last-seen ISO date.
+ *  Accumulates across reply scans; used by unfollow to protect accounts
+ *  that actually appear in the feed. */
+export function loadFeedSeen(cwd: string): Record<string, string> {
+  const file = join(cwd, FEED_SEEN_FILE);
+  if (!existsSync(file)) return {};
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function recordFeedSeen(cwd: string, tweets: Tweet[]): void {
+  const seen = loadFeedSeen(cwd);
+  const now = new Date().toISOString();
+  for (const t of tweets) {
+    if (t.authorId) seen[t.authorId] = now;
+  }
+  writeFileSync(join(cwd, FEED_SEEN_FILE), JSON.stringify(seen, null, 2));
+}
 
 interface SkipCache {
   [tweetId: string]: number; // timestamp when skipped
 }
 
-function loadSkipCache(cwd: string): SkipCache {
+export function loadSkipCache(cwd: string): SkipCache {
   const cacheFile = join(cwd, SKIP_CACHE_FILE);
   if (!existsSync(cacheFile)) return {};
   try {
@@ -44,7 +67,7 @@ function saveSkipCache(cwd: string, cache: SkipCache): void {
   writeFileSync(cacheFile, JSON.stringify(cache, null, 2));
 }
 
-function addToSkipCache(cwd: string, tweetId: string): void {
+export function addToSkipCache(cwd: string, tweetId: string): void {
   const cache = loadSkipCache(cwd);
   cache[tweetId] = Date.now();
   saveSkipCache(cwd, cache);
@@ -54,7 +77,7 @@ interface ReplyOptions {
   count?: number;
 }
 
-interface ReplyOpportunity {
+export interface ReplyOpportunity {
   tweet: Tweet;
   suggestedReply: string;
   reasoning: string;
@@ -220,7 +243,7 @@ function editReply(currentReply: string): string {
   }
 }
 
-function buildReplyPrompt(
+export function buildReplyPrompt(
   replyTemplate: string,
   styleGuide: string,
   tweets: Tweet[],
@@ -241,7 +264,7 @@ function buildReplyPrompt(
     .replace('{{TARGET_COUNT}}', targetCount);
 }
 
-function parseReplyOpportunities(
+export function parseReplyOpportunities(
   response: string,
   tweets: Tweet[]
 ): ReplyOpportunity[] {
@@ -278,6 +301,128 @@ function parseReplyOpportunities(
     logger.error(`Failed to parse LLM response: ${(error as Error).message}`);
     return [];
   }
+}
+
+/** Fetch timeline and apply all reply-candidate filters. Shared by CLI and `ship ui`. */
+export async function gatherReplyTweets(
+  apiService: XApiService,
+  username: string,
+  cwd: string,
+  maxTweets: number,
+  includeMetrics: boolean
+): Promise<Tweet[]> {
+  const { style } = logger;
+
+  let tweets = await apiService.getHomeTimeline(maxTweets, includeMetrics);
+
+  // Record every author we see — feeds the unfollow "appears in your feed" signal
+  recordFeedSeen(cwd, tweets);
+
+  // Filter out user's own tweets
+  tweets = tweets.filter((t) => t.authorUsername?.toLowerCase() !== username.toLowerCase());
+
+  // Filter out tweets we've already replied to
+  const alreadyRepliedTo = await apiService.getMyRecentReplyTargets(100);
+  if (alreadyRepliedTo.size > 0) {
+    const beforeReplyFilter = tweets.length;
+    tweets = tweets.filter((t) => !alreadyRepliedTo.has(t.id));
+    if (beforeReplyFilter > tweets.length) {
+      logger.info(style.dim(`Filtered ${beforeReplyFilter - tweets.length} tweets you already replied to`));
+    }
+  }
+
+  // Filter out previously skipped tweets (within 24 hours)
+  const skipCache = loadSkipCache(cwd);
+  const skippedIds = new Set(Object.keys(skipCache));
+  const beforeSkipFilter = tweets.length;
+  tweets = tweets.filter((t) => !skippedIds.has(t.id));
+  if (beforeSkipFilter > tweets.length) {
+    logger.info(style.dim(`Filtered ${beforeSkipFilter - tweets.length} previously skipped tweets`));
+  }
+
+  // For Basic tier: filter by engagement rate instead of raw follower count
+  if (includeMetrics) {
+    const beforeEngagementFilter = tweets.length;
+    tweets = tweets.filter((t) => {
+      const engagementRate = ((t.likeCount || 0) + (t.replyCount || 0) + (t.retweetCount || 0)) / Math.max(t.authorFollowersCount || 1, 1);
+      const isBigAccount = (t.authorFollowersCount || 0) >= 50000;
+      const isHighEngagement = engagementRate >= 0.01; // 1% engagement rate
+      return isBigAccount || isHighEngagement;
+    });
+    if (beforeEngagementFilter > tweets.length) {
+      logger.info(style.dim(`Filtered ${beforeEngagementFilter - tweets.length} tweets with low engagement rate`));
+    }
+  }
+
+  if (tweets.length === 0) return tweets;
+
+  // For Basic tier: Add replies from high-engagement threads as additional opportunities
+  if (includeMetrics) {
+    const HIGH_REPLY_THRESHOLD = 10;
+    const bigThreadTweets = tweets.filter((t) => (t.replyCount || 0) >= HIGH_REPLY_THRESHOLD);
+
+    if (bigThreadTweets.length > 0) {
+      logger.info(`Found ${bigThreadTweets.length} tweets with high reply counts, fetching conversation replies...`);
+
+      // Limit to top 3 most-engaged conversations to avoid rate limit issues
+      const topConversations = bigThreadTweets
+        .sort((a, b) => (b.replyCount || 0) - (a.replyCount || 0))
+        .slice(0, 3);
+
+      const repliesFromThreads: Tweet[] = [];
+      for (const parentTweet of topConversations) {
+        try {
+          const conversationReplies = await apiService.getRepliesFromOthers(parentTweet.id, 5);
+          // Add parentTweet reference to these replies for display context
+          for (const reply of conversationReplies) {
+            (reply as any).parentTweetForContext = parentTweet;
+          }
+          repliesFromThreads.push(...conversationReplies);
+        } catch {
+          // Silently continue if we can't fetch replies
+        }
+      }
+
+      if (repliesFromThreads.length > 0) {
+        logger.info(style.dim(`Added ${repliesFromThreads.length} replies from big threads as additional candidates`));
+        tweets.push(...repliesFromThreads);
+      }
+    }
+  }
+
+  // For Basic tier: sort by recency first, engagement second
+  if (includeMetrics) {
+    tweets = tweets.sort((a, b) => {
+      // Calculate tweet age in minutes
+      const ageA = (Date.now() - new Date(a.createdAt).getTime()) / (1000 * 60);
+      const ageB = (Date.now() - new Date(b.createdAt).getTime()) / (1000 * 60);
+
+      // Primary: tweets less than 60 minutes old sort above older tweets
+      const isRecentA = ageA < 60;
+      const isRecentB = ageB < 60;
+
+      if (isRecentA && !isRecentB) return -1;
+      if (isRecentB && !isRecentA) return 1;
+
+      // Secondary: within same recency tier, sort by engagement rate
+      if (isRecentA === isRecentB) {
+        const engagementA = ((a.likeCount || 0) + (a.replyCount || 0) + (a.retweetCount || 0)) / Math.max(a.authorFollowersCount || 1, 1);
+        const engagementB = ((b.likeCount || 0) + (b.replyCount || 0) + (b.retweetCount || 0)) / Math.max(b.authorFollowersCount || 1, 1);
+
+        if (engagementA !== engagementB) {
+          return engagementB - engagementA; // Higher engagement first
+        }
+      }
+
+      // Tertiary: by recency (newer first)
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+    logger.success(`Fetched ${tweets.length} tweets (sorted by recency & engagement)`);
+  } else {
+    logger.success(`Fetched ${tweets.length} tweets`);
+  }
+
+  return tweets;
 }
 
 export async function replyCommand(options: ReplyOptions): Promise<void> {
@@ -397,113 +542,11 @@ export async function replyCommand(options: ReplyOptions): Promise<void> {
       logger.info(`Fetching ${maxTweets} tweets from your timeline...`);
     }
 
-    let tweets = await apiService.getHomeTimeline(maxTweets, includeMetrics);
-
-    // Filter out user's own tweets
-    tweets = tweets.filter((t) => t.authorUsername?.toLowerCase() !== user.username.toLowerCase());
-
-    // Filter out tweets we've already replied to
-    const alreadyRepliedTo = await apiService.getMyRecentReplyTargets(100);
-    if (alreadyRepliedTo.size > 0) {
-      const beforeReplyFilter = tweets.length;
-      tweets = tweets.filter((t) => !alreadyRepliedTo.has(t.id));
-      if (beforeReplyFilter > tweets.length) {
-        logger.info(style.dim(`Filtered ${beforeReplyFilter - tweets.length} tweets you already replied to`));
-      }
-    }
-
-    // Filter out previously skipped tweets (within 24 hours)
-    const skipCache = loadSkipCache(cwd);
-    const skippedIds = new Set(Object.keys(skipCache));
-    const beforeSkipFilter = tweets.length;
-    tweets = tweets.filter((t) => !skippedIds.has(t.id));
-    if (beforeSkipFilter > tweets.length) {
-      logger.info(style.dim(`Filtered ${beforeSkipFilter - tweets.length} previously skipped tweets`));
-    }
-
-    // For Basic tier: filter by engagement rate instead of raw follower count
-    if (includeMetrics) {
-      const beforeEngagementFilter = tweets.length;
-      tweets = tweets.filter((t) => {
-        const engagementRate = ((t.likeCount || 0) + (t.replyCount || 0) + (t.retweetCount || 0)) / Math.max(t.authorFollowersCount || 1, 1);
-        const isBigAccount = (t.authorFollowersCount || 0) >= 50000;
-        const isHighEngagement = engagementRate >= 0.01; // 1% engagement rate
-        return isBigAccount || isHighEngagement;
-      });
-      if (beforeEngagementFilter > tweets.length) {
-        logger.info(style.dim(`Filtered ${beforeEngagementFilter - tweets.length} tweets with low engagement rate`));
-      }
-    }
+    const tweets = await gatherReplyTweets(apiService, user.username, cwd, maxTweets, includeMetrics);
 
     if (tweets.length === 0) {
       logger.error('No tweets found in timeline');
       process.exit(1);
-    }
-
-    // For Basic tier: Add replies from high-engagement threads as additional opportunities
-    if (includeMetrics) {
-      const HIGH_REPLY_THRESHOLD = 10;
-      const bigThreadTweets = tweets.filter((t) => (t.replyCount || 0) >= HIGH_REPLY_THRESHOLD);
-
-      if (bigThreadTweets.length > 0) {
-        logger.info(`Found ${bigThreadTweets.length} tweets with high reply counts, fetching conversation replies...`);
-
-        // Limit to top 3 most-engaged conversations to avoid rate limit issues
-        const topConversations = bigThreadTweets
-          .sort((a, b) => (b.replyCount || 0) - (a.replyCount || 0))
-          .slice(0, 3);
-
-        const repliesFromThreads: Tweet[] = [];
-        for (const parentTweet of topConversations) {
-          try {
-            const conversationReplies = await apiService.getRepliesFromOthers(parentTweet.id, 5);
-            // Add parentTweet reference to these replies for display context
-            for (const reply of conversationReplies) {
-              (reply as any).parentTweetForContext = parentTweet;
-            }
-            repliesFromThreads.push(...conversationReplies);
-          } catch {
-            // Silently continue if we can't fetch replies
-          }
-        }
-
-        if (repliesFromThreads.length > 0) {
-          logger.info(style.dim(`Added ${repliesFromThreads.length} replies from big threads as additional candidates`));
-          tweets.push(...repliesFromThreads);
-        }
-      }
-    }
-
-    // For Basic tier: sort by recency first, engagement second
-    if (includeMetrics) {
-      tweets = tweets.sort((a, b) => {
-        // Calculate tweet age in minutes
-        const ageA = (Date.now() - new Date(a.createdAt).getTime()) / (1000 * 60);
-        const ageB = (Date.now() - new Date(b.createdAt).getTime()) / (1000 * 60);
-
-        // Primary: tweets less than 60 minutes old sort above older tweets
-        const isRecentA = ageA < 60;
-        const isRecentB = ageB < 60;
-
-        if (isRecentA && !isRecentB) return -1;
-        if (isRecentB && !isRecentA) return 1;
-
-        // Secondary: within same recency tier, sort by engagement rate
-        if (isRecentA === isRecentB) {
-          const engagementA = ((a.likeCount || 0) + (a.replyCount || 0) + (a.retweetCount || 0)) / Math.max(a.authorFollowersCount || 1, 1);
-          const engagementB = ((b.likeCount || 0) + (b.replyCount || 0) + (b.retweetCount || 0)) / Math.max(b.authorFollowersCount || 1, 1);
-
-          if (engagementA !== engagementB) {
-            return engagementB - engagementA; // Higher engagement first
-          }
-        }
-
-        // Tertiary: by recency (newer first)
-        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-      });
-      logger.success(`Fetched ${tweets.length} tweets (sorted by recency & engagement)`);
-    } else {
-      logger.success(`Fetched ${tweets.length} tweets`);
     }
 
     // Load prompts

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -11,7 +11,7 @@ import type { UserV2WithMetrics, TweetV2WithMetrics } from '../types/x-api-respo
 const STATS_CACHE_FILE = '.shippost-stats-cache.json';
 const STATS_CACHE_MAX_AGE = 60 * 60 * 1000; // 1 hour (Basic tier has strict rate limits)
 
-interface TweetWithMetrics {
+export interface TweetWithMetrics {
   id: string;
   text: string;
   createdAt: string;
@@ -302,7 +302,7 @@ export async function statsCommand(): Promise<void> {
 }
 
 // Helper to get user metrics
-async function getMeWithMetrics(accessToken: string): Promise<{ followers: number; following: number; tweets: number } | null> {
+export async function getMeWithMetrics(accessToken: string): Promise<{ followers: number; following: number; tweets: number } | null> {
   try {
     const { TwitterApi } = await import('twitter-api-v2');
     const client = new TwitterApi(accessToken);
@@ -320,7 +320,7 @@ async function getMeWithMetrics(accessToken: string): Promise<{ followers: numbe
 }
 
 // Helper to get tweets with full metrics (paginates to get up to `count` tweets)
-async function getRecentTweetsWithMetrics(accessToken: string, userId: string, count: number): Promise<TweetWithMetrics[]> {
+export async function getRecentTweetsWithMetrics(accessToken: string, userId: string, count: number): Promise<TweetWithMetrics[]> {
   try {
     const { TwitterApi } = await import('twitter-api-v2');
     const client = new TwitterApi(accessToken);
@@ -398,7 +398,7 @@ async function getRecentTweetsWithMetrics(accessToken: string, userId: string, c
   }
 }
 
-function getDailyPostCounts(tweets: TweetWithMetrics[], days: number): number[] {
+export function getDailyPostCounts(tweets: TweetWithMetrics[], days: number): number[] {
   const counts: number[] = new Array(days).fill(0);
   const now = new Date();
 
@@ -412,7 +412,7 @@ function getDailyPostCounts(tweets: TweetWithMetrics[], days: number): number[] 
   return counts;
 }
 
-function getDailyImpressions(tweets: TweetWithMetrics[], days: number): number[] {
+export function getDailyImpressions(tweets: TweetWithMetrics[], days: number): number[] {
   const totals: number[] = new Array(days).fill(0);
   const now = new Date();
 
@@ -426,7 +426,7 @@ function getDailyImpressions(tweets: TweetWithMetrics[], days: number): number[]
   return totals;
 }
 
-function getHourlyEngagement(tweets: TweetWithMetrics[]): { hour: number; avgEngagement: number }[] {
+export function getHourlyEngagement(tweets: TweetWithMetrics[]): { hour: number; avgEngagement: number }[] {
   const hourData: { total: number; count: number }[] = new Array(24).fill(null).map(() => ({ total: 0, count: 0 }));
 
   tweets.forEach(t => {

--- a/src/commands/ui/index.ts
+++ b/src/commands/ui/index.ts
@@ -1,0 +1,747 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { spawn, exec } from 'child_process';
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { join, basename } from 'path';
+import { FileSystemService } from '../../services/file-system.js';
+import { TypefullyService } from '../../services/typefully.js';
+import { AnthropicService } from '../../services/anthropic.js';
+import { XAuthService } from '../../services/x-auth.js';
+import { XApiService, RateLimitError } from '../../services/x-api.js';
+import { createLLMService } from '../../services/llm-factory.js';
+import { logger } from '../../utils/logger.js';
+import { isShippostProject } from '../../utils/validation.js';
+import { NotInitializedError } from '../../utils/errors.js';
+import type { Post } from '../../types/post.js';
+import {
+  gatherReplyTweets,
+  buildReplyPrompt,
+  parseReplyOpportunities,
+  addToSkipCache,
+  loadFeedSeen,
+} from '../reply.js';
+import {
+  getMeWithMetrics,
+  getRecentTweetsWithMetrics,
+  getDailyPostCounts,
+  getDailyImpressions,
+  getHourlyEngagement,
+  type TweetWithMetrics,
+} from '../stats.js';
+import {
+  buildCandidates,
+  loadFollowingCache,
+  saveFollowingCache,
+  removeFromCache,
+  loadWhitelist,
+  addToWhitelist,
+} from '../unfollow.js';
+import {
+  loadGranolaRefreshToken,
+  refreshAccessToken,
+  fetchGranolaDocuments,
+} from '../granola-sync.js';
+import { PAGE } from './page.js';
+
+const TRANSCRIPT_META_FILE = '.shippost-transcript-meta.json';
+const RELEVANCE_CACHE_FILE = '.shippost-relevance-cache.json';
+const PENDING_UNFOLLOW_FILE = '.shippost-unfollow-pending.json';
+
+/** Durable unfollow decisions, id → {username, queuedAt}. Held across cap
+ *  hits and server restarts; drained by the unfollow worker. */
+function loadPendingUnfollows(cwd: string): Record<string, { username: string; queuedAt: string }> {
+  try {
+    return JSON.parse(readFileSync(join(cwd, PENDING_UNFOLLOW_FILE), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+async function savePendingUnfollows(cwd: string, pending: Record<string, { username: string; queuedAt: string }>): Promise<void> {
+  const { writeFileSync } = await import('fs');
+  writeFileSync(join(cwd, PENDING_UNFOLLOW_FILE), JSON.stringify(pending, null, 2));
+}
+
+// What "relevant to Ry" means for follow-list curation
+const RY_INTERESTS =
+  'agentic engineering and AI coding agents, developer tools, startups/founders/venture, ' +
+  'cloud infrastructure, Postgres and data systems, engineering leadership, Cincinnati tech';
+
+interface TranscriptMeta {
+  [filename: string]: { attendees?: string[]; summary?: string; skipped?: boolean };
+}
+
+interface UiOptions {
+  port?: number;
+  minScore?: number;
+}
+
+interface Job {
+  running: boolean;
+  log: string[];
+  result?: unknown;
+  error?: string;
+}
+
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+export async function uiCommand(options: UiOptions): Promise<void> {
+  const cwd = process.cwd();
+  const fs = new FileSystemService(cwd);
+  let typefully: TypefullyService | null = null;
+  let anthropic: AnthropicService | null = null;
+  const jobs: Record<string, Job> = {};
+  const genQueue: string[] = [];
+  let genActive: string | null = null;
+
+  // Drain the durable pending-unfollow ledger; cap/rate-limit hits leave the
+  // rest pending for a later retry.
+  const runUnfollowWorker = () => startJob('unfollow-run', async (job) => {
+    const { api } = await xApi();
+    let done = 0;
+    while (true) {
+      const pending = loadPendingUnfollows(cwd);
+      const ids = Object.keys(pending);
+      if (!ids.length) break;
+      const id = ids[0];
+      const uname = pending[id].username || id;
+      try {
+        await api.unfollowUser(id);
+        removeFromCache(cwd, id);
+        delete pending[id];
+        await savePendingUnfollows(cwd, pending);
+        done++;
+        job.log.push(`✗ @${uname} unfollowed (${ids.length - 1} pending)`);
+      } catch (error) {
+        const msg = (error as Error).message;
+        if (error instanceof RateLimitError || msg.includes('402')) {
+          job.log.push(msg.includes('402')
+            ? `✗ X monthly cap — holding ${ids.length} decisions, will retry on next server start or Retry click`
+            : `⏳ rate limited — holding ${ids.length} decisions, retry in ~15 min`);
+          break;
+        }
+        // Hard per-account failure (deactivated, suspended) — drop the decision
+        delete pending[id];
+        await savePendingUnfollows(cwd, pending);
+        job.log.push(`skipped @${uname}: ${msg}`);
+      }
+      if (Object.keys(loadPendingUnfollows(cwd)).length) {
+        await new Promise((r) => setTimeout(r, 20000)); // pace under 50/15min
+      }
+    }
+    job.result = { unfollowed: done, pending: Object.keys(loadPendingUnfollows(cwd)).length };
+  });
+  const metaPath = join(cwd, TRANSCRIPT_META_FILE);
+
+  const loadMeta = (): TranscriptMeta => {
+    try {
+      return JSON.parse(readFileSync(metaPath, 'utf8'));
+    } catch {
+      return {};
+    }
+  };
+  const saveMeta = async (meta: TranscriptMeta) => {
+    const { writeFileSync } = await import('fs');
+    writeFileSync(metaPath, JSON.stringify(meta, null, 2));
+  };
+
+  // One Granola fetch per server run: filename → attendee names (excluding Ry).
+  let attendeesPromise: Promise<Record<string, string[]>> | null = null;
+  const granolaAttendees = (): Promise<Record<string, string[]>> => {
+    if (!attendeesPromise) {
+      attendeesPromise = (async () => {
+        const statePath = join(cwd, '.granola-sync-state.json');
+        if (!existsSync(statePath)) return {};
+        const syncState = JSON.parse(readFileSync(statePath, 'utf8'));
+        const docToFile: Record<string, string> = {};
+        for (const [docId, v] of Object.entries(syncState.syncedDocuments || {})) {
+          docToFile[docId] = (v as { filename: string }).filename;
+        }
+        const token = await refreshAccessToken(loadGranolaRefreshToken());
+        const docs = await fetchGranolaDocuments(token);
+        const out: Record<string, string[]> = {};
+        for (const [docId, doc] of Object.entries(docs)) {
+          const filename = docToFile[docId];
+          if (!filename) continue;
+          const raw = doc.google_calendar_event?.attendees?.map((a) => a.displayName || a.email || '')
+            || doc.people?.attendees?.map((a) => a.name || a.email || '')
+            || [];
+          const names = [...new Set(raw
+            .filter(Boolean)
+            .filter((n) => !/^ry@|ry walker/i.test(n))
+            .map((n) => n.includes('@') ? n.split('@')[0] : n))];
+          if (names.length) out[filename] = names;
+        }
+        return out;
+      })().catch(() => ({}));
+    }
+    return attendeesPromise;
+  };
+
+  const startJob = (name: string, fn: (job: Job) => Promise<void>): boolean => {
+    if (jobs[name]?.running) return false;
+    const job: Job = { running: true, log: [] };
+    jobs[name] = job;
+    fn(job)
+      .catch((err) => { job.error = (err as Error).message; job.log.push(`✗ ${(err as Error).message}`); })
+      .finally(() => { job.running = false; });
+    return true;
+  };
+
+  const xApi = async (): Promise<{ api: XApiService; username: string }> => {
+    const config = fs.loadConfig();
+    const clientId = config.x?.clientId;
+    if (!clientId) throw new Error('X API not configured. Run `ship analyze-x --setup` first.');
+    const auth = new XAuthService(cwd, clientId);
+    const token = await auth.getValidToken();
+    const api = new XApiService(token);
+    const me = await api.getMe();
+    return { api, username: me.username };
+  };
+
+  try {
+    if (!isShippostProject(cwd)) {
+      throw new NotInitializedError();
+    }
+    const config = fs.loadConfig();
+    const port = options.port || 4747;
+
+    const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      const send = (status: number, body: string, type = 'application/json') => {
+        res.writeHead(status, { 'Content-Type': type, 'Cache-Control': 'no-store' });
+        res.end(body);
+      };
+      const readBody = async (): Promise<Record<string, unknown>> => {
+        let raw = '';
+        for await (const chunk of req) raw += chunk;
+        return JSON.parse(raw || '{}');
+      };
+      const url = new URL(req.url || '/', `http://127.0.0.1:${port}`);
+      const route = `${req.method} ${url.pathname}`;
+
+      try {
+        if (route === 'GET /') return send(200, PAGE, 'text/html');
+
+        // ── jobs ─────────────────────────────────────────────────────
+        if (req.method === 'GET' && url.pathname.startsWith('/api/job/')) {
+          const job = jobs[url.pathname.slice('/api/job/'.length)];
+          if (!job) return send(200, JSON.stringify({ running: false, log: [] }));
+          return send(200, JSON.stringify(job));
+        }
+
+        // ── review ───────────────────────────────────────────────────
+        if (route === 'GET /api/posts') {
+          let posts = fs.readPosts().filter((p) => p.status === 'new' || p.status === 'keep');
+          if (options.minScore !== undefined) {
+            posts = posts.filter((p) => (p.metadata.bangerScore || 0) >= options.minScore!);
+          }
+          const sorted = [...posts].sort((a, b) => (b.metadata.bangerScore || 0) - (a.metadata.bangerScore || 0));
+          const queue = sorted.map((p) => ({
+            id: p.id,
+            platform: p.platform || 'x',
+            score: p.metadata.bangerScore || 0,
+            sourceFile: p.sourceFile,
+            content: p.content,
+          }));
+          return send(200, JSON.stringify({ posts: queue }));
+        }
+
+        if (route === 'POST /api/decision') {
+          const { id, action, content } = await readBody();
+          const post = fs.readPosts().find((p) => p.id === id);
+          if (!post) return send(404, JSON.stringify({ error: 'post not found' }));
+          if (action !== 'stage' && action !== 'reject') {
+            return send(400, JSON.stringify({ error: 'action must be stage or reject' }));
+          }
+          const finalContent = typeof content === 'string' && content.trim() ? content : post.content;
+          let shareUrl: string | undefined;
+          if (action === 'stage') {
+            if (!typefully) typefully = new TypefullyService(config.typefully?.socialSetId);
+            const draft = await typefully.createDraft(finalContent, post.platform || 'x');
+            post.metadata.typefullyDraftId = draft.id;
+            shareUrl = draft.share_url;
+          }
+          post.content = finalContent;
+          post.status = action === 'stage' ? 'staged' : 'rejected';
+          fs.updatePost(post.id, () => post);
+          logger.info(`${action === 'stage' ? 'Staged' : 'Rejected'}: ${finalContent.slice(0, 60).replace(/\n/g, ' ')}…`);
+          return send(200, JSON.stringify({ ok: true, share_url: shareUrl }));
+        }
+
+        if (route === 'POST /api/rewrite') {
+          const { content, start, end, instruction, platform } = await readBody() as {
+            content: string; start: number; end: number; instruction: string; platform?: string;
+          };
+          if (typeof content !== 'string' || typeof instruction !== 'string' || !(end > start)) {
+            return send(400, JSON.stringify({ error: 'need content, selection range, instruction' }));
+          }
+          if (!anthropic) anthropic = new AnthropicService(config);
+          let style = '';
+          try {
+            style = readFileSync(join(cwd, 'prompts', 'style.md'), 'utf-8');
+          } catch { /* style guide optional */ }
+          const selection = content.slice(start, end);
+          const prompt = [
+            `You are editing a ${platform === 'linkedin' ? 'LinkedIn' : 'X'} post or reply.`,
+            style ? `Author's style guide:\n<style>\n${style}\n</style>` : '',
+            `Full text:\n<post>\n${content}\n</post>`,
+            `The author selected this span:\n<selection>\n${selection}\n</selection>`,
+            `Instruction: ${instruction}`,
+            `Rewrite ONLY the selected span per the instruction, matching the surrounding voice. Never use em dashes. Return ONLY the replacement text for the span — no quotes around it, no preamble, no explanation.`,
+          ].filter(Boolean).join('\n\n');
+          let replacement = (await anthropic.generate(prompt)).trim();
+          replacement = replacement.replace(/^(Here('|’)s.*?:|Replacement:)\s*/i, '').trim();
+          if (replacement.length >= 2 && replacement.startsWith('"') && replacement.endsWith('"') && !selection.startsWith('"')) {
+            replacement = replacement.slice(1, -1);
+          }
+          return send(200, JSON.stringify({ replacement }));
+        }
+
+        // ── generate ─────────────────────────────────────────────────
+        if (route === 'GET /api/transcripts') {
+          const inputDir = join(cwd, 'input');
+          const state = fs.loadState();
+          const files = existsSync(inputDir)
+            ? readdirSync(inputDir).filter((f) => f.endsWith('.txt') || f.endsWith('.md'))
+            : [];
+          const attendees = await granolaAttendees();
+          const meta = loadMeta();
+          const unprocessed = files
+            .filter((f) => !fs.isFileProcessed(join(inputDir, f), state))
+            .filter((f) => !loadMeta()[f]?.skipped)
+            .filter((f) => f !== genActive && !genQueue.includes(f))
+            .map((f) => {
+              const st = statSync(join(inputDir, f));
+              return {
+                name: f,
+                size: st.size,
+                modified: st.mtime.toISOString(),
+                attendees: attendees[f] || meta[f]?.attendees || [],
+                summary: meta[f]?.summary || null,
+              };
+            })
+            .sort((a, b) => b.name.localeCompare(a.name));
+          // Persist attendees so they survive Granola auth hiccups
+          let dirty = false;
+          for (const t of unprocessed) {
+            if (t.attendees.length && !meta[t.name]?.attendees) {
+              meta[t.name] = { ...meta[t.name], attendees: t.attendees };
+              dirty = true;
+            }
+          }
+          if (dirty) await saveMeta(meta);
+          return send(200, JSON.stringify({ transcripts: unprocessed }));
+        }
+
+        if (req.method === 'GET' && url.pathname === '/api/transcripts/content') {
+          const name = basename(url.searchParams.get('name') || '');
+          const file = join(cwd, 'input', name);
+          if (!name || !existsSync(file)) return send(404, JSON.stringify({ error: 'transcript not found' }));
+          return send(200, JSON.stringify({ content: readFileSync(file, 'utf8') }));
+        }
+
+        if (route === 'POST /api/transcripts/skip') {
+          const { name } = await readBody() as { name: string };
+          const key = basename(String(name));
+          const meta = loadMeta();
+          meta[key] = { ...meta[key], skipped: true };
+          await saveMeta(meta);
+          return send(200, JSON.stringify({ ok: true }));
+        }
+
+        if (route === 'GET /api/generate/status') {
+          const job = jobs['generate'];
+          return send(200, JSON.stringify({
+            running: job?.running ?? false,
+            active: genActive,
+            queued: genQueue.length,
+            lastLine: job?.log.filter((l) => l.trim()).slice(-1)[0] || '',
+            error: job?.error || null,
+          }));
+        }
+
+        if (route === 'POST /api/transcripts/summary') {
+          const { name } = await readBody() as { name: string };
+          const file = join(cwd, 'input', basename(String(name)));
+          if (!existsSync(file)) return send(404, JSON.stringify({ error: 'transcript not found' }));
+          const meta = loadMeta();
+          if (meta[basename(String(name))]?.summary) {
+            return send(200, JSON.stringify({ summary: meta[basename(String(name))].summary }));
+          }
+          const text = readFileSync(file, 'utf8').slice(0, 8000);
+          // Haiku for cheap metadata — this is internal, not published content
+          const { default: Anthropic } = await import('@anthropic-ai/sdk');
+          const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+          const msg = await client.messages.create({
+            model: 'claude-haiku-4-5-20251001',
+            max_tokens: 80,
+            messages: [{
+              role: 'user',
+              content: `One sentence, max 20 words: what was this meeting about? No preamble.\n\n${text}`,
+            }],
+          });
+          const block = msg.content.find((b) => b.type === 'text');
+          const summary = (block && block.type === 'text' ? block.text : '').trim();
+          meta[basename(String(name))] = { ...meta[basename(String(name))], summary };
+          await saveMeta(meta);
+          return send(200, JSON.stringify({ summary }));
+        }
+
+        if (route === 'POST /api/generate') {
+          const { files } = await readBody() as { files: string[] };
+          if (!Array.isArray(files) || files.length === 0) {
+            return send(400, JSON.stringify({ error: 'no files selected' }));
+          }
+          const requested = files.map((f) => basename(String(f)));
+          // Guard against double-processing: skip files already queued, active,
+          // or being worked by an orphaned pre-restart child process
+          const { execSync } = await import('child_process');
+          const accepted = requested.filter((f) => {
+            if (genQueue.includes(f) || genActive === f) return false;
+            try {
+              execSync(`pgrep -f "work --all --files ${f.replace(/[^a-zA-Z0-9._-]/g, '')}"`, { stdio: 'pipe' });
+              return false; // an orphaned run is already on it
+            } catch {
+              return true; // pgrep found nothing
+            }
+          });
+          if (accepted.length === 0) return send(409, JSON.stringify({ error: 'already processing' }));
+          genQueue.push(...accepted);
+          startJob('generate', async (job) => {
+            let file: string | undefined;
+            try {
+              while ((file = genQueue.shift())) {
+                const f = file;
+                genActive = f;
+                job.log.push(`▸ ${f}`);
+                await new Promise<void>((resolve, reject) => {
+                  const child = spawn(process.execPath, [process.argv[1], 'work', '--all', '--files', f], { cwd });
+                  const onData = (chunk: Buffer) => {
+                    stripAnsi(chunk.toString()).split('\n').forEach((line) => {
+                      if (line.trim()) job.log.push(line.trimEnd());
+                    });
+                  };
+                  child.stdout.on('data', onData);
+                  child.stderr.on('data', onData);
+                  child.on('close', (code) => (code === 0 ? resolve() : reject(new Error(`ship work exited with code ${code}`))));
+                  child.on('error', reject);
+                });
+              }
+            } finally {
+              genActive = null;
+            }
+          });
+          return send(202, JSON.stringify({ queued: genQueue.length }));
+        }
+
+        // ── reply ────────────────────────────────────────────────────
+        if (route === 'POST /api/reply/scan') {
+          const ok = startJob('reply', async (job) => {
+            job.log.push('Connecting to X…');
+            const { api, username } = await xApi();
+            job.log.push(`Authenticated as @${username}`);
+            const apiTier = config.x?.apiTier || 'free';
+            const includeMetrics = apiTier === 'basic';
+            const maxTweets = includeMetrics ? 30 : 10;
+            job.log.push(`Fetching ${maxTweets} tweets…`);
+            const tweets = await gatherReplyTweets(api, username, cwd, maxTweets, includeMetrics);
+            if (tweets.length === 0) {
+              job.result = { opportunities: [] };
+              return;
+            }
+            job.log.push(`Analyzing ${tweets.length} tweets for reply opportunities…`);
+            const styleGuide = fs.loadPrompt('style.md');
+            const replyTemplate = fs.loadPrompt('reply.md');
+            const llm = createLLMService(config);
+            const response = await llm.generate(buildReplyPrompt(replyTemplate, styleGuide, tweets, includeMetrics));
+            const opportunities = parseReplyOpportunities(response, tweets);
+            job.log.push(`Found ${opportunities.length} opportunities`);
+            job.result = {
+              opportunities: opportunities.map((o) => ({
+                tweetId: o.tweet.id,
+                author: o.tweet.authorUsername || 'unknown',
+                followers: o.tweet.authorFollowersCount || 0,
+                text: o.tweet.text,
+                likes: o.tweet.likeCount || 0,
+                replies: o.tweet.replyCount || 0,
+                retweets: o.tweet.retweetCount || 0,
+                createdAt: o.tweet.createdAt,
+                url: o.tweet.authorUsername
+                  ? `https://x.com/${o.tweet.authorUsername}/status/${o.tweet.id}`
+                  : `https://x.com/i/status/${o.tweet.id}`,
+                suggestedReply: o.suggestedReply,
+                reasoning: o.reasoning,
+                parentText: o.parentTweet?.text,
+                parentAuthor: o.parentTweet?.authorUsername,
+              })),
+            };
+          });
+          return ok
+            ? send(202, JSON.stringify({ started: true }))
+            : send(409, JSON.stringify({ error: 'scan already running' }));
+        }
+
+        if (route === 'POST /api/reply/post') {
+          const { tweetId, text } = await readBody() as { tweetId: string; text: string };
+          if (!tweetId || !text?.trim()) return send(400, JSON.stringify({ error: 'need tweetId and text' }));
+          const { api } = await xApi();
+          const posted = await api.postReply(tweetId, text.trim());
+          try {
+            await api.likeTweet(tweetId);
+          } catch { /* best-effort like */ }
+          logger.info(`Replied to ${tweetId}`);
+          return send(200, JSON.stringify({ ok: true, url: `https://x.com/i/status/${posted.id}` }));
+        }
+
+        if (route === 'POST /api/reply/skip') {
+          const { tweetId } = await readBody() as { tweetId: string };
+          if (!tweetId) return send(400, JSON.stringify({ error: 'need tweetId' }));
+          addToSkipCache(cwd, tweetId);
+          return send(200, JSON.stringify({ ok: true }));
+        }
+
+        // ── stats ────────────────────────────────────────────────────
+        if (route === 'GET /api/stats') {
+          const clientId = config.x?.clientId;
+          if (!clientId) return send(400, JSON.stringify({ error: 'X API not configured' }));
+          if ((config.x?.apiTier || 'free') !== 'basic') {
+            return send(400, JSON.stringify({ error: 'Stats requires Basic X API tier' }));
+          }
+          const auth = new XAuthService(cwd, clientId);
+          const token = await auth.getValidToken();
+          const api = new XApiService(token);
+          const me = await api.getMe();
+          const account = await getMeWithMetrics(token);
+
+          const cacheFile = join(cwd, '.shippost-stats-cache.json');
+          let tweets: TweetWithMetrics[] = [];
+          let cached = false;
+          if (existsSync(cacheFile)) {
+            try {
+              const c = JSON.parse(readFileSync(cacheFile, 'utf8'));
+              if (c.userId === me.id && Date.now() - c.timestamp < 60 * 60 * 1000) {
+                tweets = c.tweets;
+                cached = true;
+              }
+            } catch { /* ignore invalid cache */ }
+          }
+          if (!cached) {
+            tweets = await getRecentTweetsWithMetrics(token, me.id, 100);
+            const { writeFileSync } = await import('fs');
+            writeFileSync(cacheFile, JSON.stringify({ tweets, timestamp: Date.now(), userId: me.id }));
+          }
+
+          const now = Date.now();
+          const within = (days: number) => tweets.filter((t) => now - new Date(t.createdAt).getTime() < days * 86400000);
+          const sum = (arr: TweetWithMetrics[]) => ({
+            posts: arr.length,
+            impressions: arr.reduce((s, t) => s + t.impressions, 0),
+            likes: arr.reduce((s, t) => s + t.likes, 0),
+            replies: arr.reduce((s, t) => s + t.replies, 0),
+            retweets: arr.reduce((s, t) => s + t.retweets, 0),
+            bookmarks: arr.reduce((s, t) => s + t.bookmarks, 0),
+            engagementRate: arr.length ? arr.reduce((s, t) => s + t.engagementRate, 0) / arr.length : 0,
+          });
+          const d7 = sum(within(7));
+          const dailyAvg = d7.impressions / 7;
+          const topPost = [...within(7)].sort((a, b) => b.impressions - a.impressions)[0] || null;
+          const bestHours = getHourlyEngagement(within(30))
+            .sort((a, b) => b.avgEngagement - a.avgEngagement)
+            .slice(0, 3)
+            .map((h) => h.hour);
+
+          return send(200, JSON.stringify({
+            username: me.username,
+            account,
+            h24: sum(within(1)),
+            d7,
+            d30: sum(within(30)),
+            goal: { target: 5_000_000, projected: Math.round(dailyAvg * 90), dailyAvg: Math.round(dailyAvg) },
+            dailyPosts: getDailyPostCounts(tweets, 14),
+            dailyImpressions: getDailyImpressions(tweets, 14),
+            bestHours,
+            topPost: topPost ? { text: topPost.text, impressions: topPost.impressions, likes: topPost.likes } : null,
+            cached,
+          }));
+        }
+
+        // ── unfollow ─────────────────────────────────────────────────
+        if (route === 'POST /api/unfollow/scan') {
+          const ok = startJob('unfollow-scan', async (job) => {
+            job.log.push('Connecting to X…');
+            const { api, username } = await xApi();
+            job.log.push(`Authenticated as @${username}`);
+            let following = loadFollowingCache(cwd);
+            if (following) {
+              job.log.push(`Using cached following list (${following.length})`);
+            } else {
+              job.log.push('Fetching following list (may take a minute)…');
+              following = await api.getFollowing(6000);
+              saveFollowingCache(cwd, following);
+              job.log.push(`Fetched ${following.length} accounts`);
+            }
+
+            // Bios ride along on the following list (user.fields=description).
+            // A cache from before bio support has none — try to refresh, but the
+            // X monthly read cap (402) makes this best-effort.
+            const haveBios = following.some((f) => f.bio !== undefined);
+            if (following.length && !haveBios) {
+              job.log.push('Cached following list predates bios — refetching…');
+              try {
+                following = await api.getFollowing(6000);
+                saveFollowingCache(cwd, following);
+                job.log.push(`Refetched ${following.length} accounts with bios`);
+              } catch (err) {
+                job.log.push(`⚠ Could not refetch bios (${(err as Error).message.split('\n')[0]}) — scoring on names/metrics only for now`);
+              }
+            }
+            const biosAvailable = following.some((f) => f.bio !== undefined);
+            const bios: Record<string, string> = {};
+            for (const f of following) bios[f.id] = f.bio || '';
+
+            // Relevance scores (permanent cache; score only new accounts)
+            let relCache: Record<string, { score: number; note: string; username: string; bioScored?: boolean }> = {};
+            try {
+              relCache = JSON.parse(readFileSync(join(cwd, RELEVANCE_CACHE_FILE), 'utf8'));
+            } catch { /* no cache yet */ }
+            // Score new accounts; also rescore bio-less scores once bios arrive
+            const unscored = following.filter((f) => !relCache[f.id] || (biosAvailable && !relCache[f.id].bioScored));
+            if (unscored.length) {
+              job.log.push(`Scoring relevance for ${unscored.length} accounts with Haiku…`);
+              const { default: Anthropic } = await import('@anthropic-ai/sdk');
+              const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+              const BATCH = 40;
+              for (let i = 0; i < unscored.length; i += BATCH) {
+                const batch = unscored.slice(i, i + BATCH);
+                const listing = batch.map((a) =>
+                  `${a.id} | @${a.username} | ${a.followersCount} followers, ${a.tweetCount} posts | ${(bios[a.id] || '(no bio)').replace(/\n/g, ' ').slice(0, 200)}`
+                ).join('\n');
+                const prompt =
+                  `Ry follows these X accounts. His interests: ${RY_INTERESTS}.\n` +
+                  `For each account, score 0-100 how relevant it is for him to keep following ` +
+                  `(0 = spam/crypto-giveaway/irrelevant, 50 = unclear, 100 = squarely his world), ` +
+                  `with a note of at most 6 words. A missing bio is NOT evidence of irrelevance — ` +
+                  `if you cannot tell who they are, score 45-55, never 0.\n` +
+                  `Return ONLY a JSON array: [{"id":"...","score":N,"note":"..."}]\n\n${listing}`;
+                try {
+                  const msg = await client.messages.create({
+                    model: 'claude-haiku-4-5-20251001',
+                    max_tokens: 4000,
+                    messages: [{ role: 'user', content: prompt }],
+                  });
+                  const block = msg.content.find((b) => b.type === 'text');
+                  const text = block && block.type === 'text' ? block.text : '[]';
+                  const arr = JSON.parse(text.match(/\[[\s\S]*\]/)?.[0] || '[]');
+                  for (const r of arr) {
+                    const acct = batch.find((a) => a.id === String(r.id));
+                    if (acct && typeof r.score === 'number') {
+                      relCache[acct.id] = { score: r.score, note: String(r.note || ''), username: acct.username, bioScored: biosAvailable };
+                    }
+                  }
+                } catch (err) {
+                  job.log.push(`scoring batch failed: ${(err as Error).message}`);
+                }
+                // Save after every batch so restarts don't lose progress
+                const { writeFileSync } = await import('fs');
+                writeFileSync(join(cwd, RELEVANCE_CACHE_FILE), JSON.stringify(relCache, null, 2));
+                job.log.push(`Scored ${Math.min(i + BATCH, unscored.length)}/${unscored.length}`);
+              }
+            } else {
+              job.log.push('All accounts already relevance-scored');
+            }
+
+            // Protect accounts that actually show up in Ry's feed (seen in last 30 days)
+            const feedSeen = loadFeedSeen(cwd);
+            const feedCutoff = Date.now() - 30 * 86400000;
+            const seenRecently = (id: string) =>
+              feedSeen[id] !== undefined && new Date(feedSeen[id]).getTime() > feedCutoff;
+
+            const whitelist = loadWhitelist(cwd);
+            const pendingUnf = loadPendingUnfollows(cwd);
+            const eligible = following.filter((a) => !pendingUnf[a.id] && !whitelist[a.id] && !seenRecently(a.id));
+
+            const qualityCands = new Map(buildCandidates(eligible, { minFollowers: 500 }).map((c) => [c.id, c]));
+            const combined = eligible
+              .map((a) => {
+                const rel = relCache[a.id];
+                const quality = qualityCands.get(a.id);
+                const lowRelevance = rel !== undefined && rel.score < 30;
+                if (!quality && !lowRelevance) return null;
+                const reasons: string[] = [];
+                if (quality) reasons.push(quality.reason);
+                if (rel && rel.score < 50) reasons.push(`relevance ${rel.score}${rel.note ? ': ' + rel.note : ''}`);
+                return {
+                  id: a.id,
+                  username: a.username,
+                  name: a.name,
+                  followers: a.followersCount,
+                  tweets: a.tweetCount,
+                  relevance: rel?.score ?? null,
+                  reason: reasons.join(' · '),
+                };
+              })
+              .filter((c): c is NonNullable<typeof c> => c !== null)
+              .sort((a, b) => (a.relevance ?? 50) - (b.relevance ?? 50) || a.followers - b.followers);
+
+            job.result = {
+              followingCount: following.length,
+              pendingCount: Object.keys(pendingUnf).length,
+              candidates: combined.slice(0, 200),
+            };
+          });
+          return ok
+            ? send(202, JSON.stringify({ started: true }))
+            : send(409, JSON.stringify({ error: 'scan already running' }));
+        }
+
+        if (route === 'POST /api/unfollow/whitelist') {
+          const { entries } = await readBody() as { entries: { id: string; username: string }[] };
+          if (!Array.isArray(entries) || entries.length === 0) return send(400, JSON.stringify({ error: 'no accounts selected' }));
+          addToWhitelist(cwd, entries.map((e) => ({ id: String(e.id), username: String(e.username || '') })));
+          return send(200, JSON.stringify({ ok: true, count: entries.length }));
+        }
+
+        if (route === 'POST /api/unfollow/run') {
+          const { ids, entries } = await readBody() as { ids?: string[]; entries?: { id: string; username: string }[] };
+          const toAdd = entries?.length
+            ? entries.map((e) => ({ id: String(e.id), username: String(e.username || '') }))
+            : (ids || []).map((id) => ({ id: String(id), username: '' }));
+          if (toAdd.length === 0) return send(400, JSON.stringify({ error: 'no accounts selected' }));
+          const pending = loadPendingUnfollows(cwd);
+          const now = new Date().toISOString();
+          for (const e of toAdd) pending[e.id] = { username: e.username, queuedAt: now };
+          await savePendingUnfollows(cwd, pending);
+          runUnfollowWorker();
+          return send(202, JSON.stringify({ pending: Object.keys(pending).length }));
+        }
+
+        if (route === 'POST /api/unfollow/retry') {
+          const pending = loadPendingUnfollows(cwd);
+          if (Object.keys(pending).length === 0) return send(200, JSON.stringify({ pending: 0 }));
+          runUnfollowWorker();
+          return send(202, JSON.stringify({ pending: Object.keys(pending).length }));
+        }
+
+        send(404, JSON.stringify({ error: 'not found' }));
+      } catch (error) {
+        send(500, JSON.stringify({ error: (error as Error).message }));
+      }
+    });
+
+    server.listen(port, '127.0.0.1', () => {
+      const url = `http://127.0.0.1:${port}`;
+      logger.blank();
+      logger.success(`ship ui running at ${url}`);
+      logger.info('  Review • Generate • Reply • Stats • Unfollow — Ctrl-C here when done');
+      const pending = Object.keys(loadPendingUnfollows(cwd)).length;
+      if (pending > 0) {
+        logger.info(`  ${pending} pending unfollow decision${pending === 1 ? '' : 's'} — retrying`);
+        runUnfollowWorker();
+      }
+      exec(`open ${url}`);
+    });
+  } catch (error) {
+    logger.blank();
+    logger.error((error as Error).message);
+    process.exit(1);
+  }
+}

--- a/src/commands/ui/page.ts
+++ b/src/commands/ui/page.ts
@@ -1,0 +1,663 @@
+// Single-page client for `ship ui`. Served inline — no build step, no deps.
+// Client JS uses string concatenation (not template literals) because this
+// whole page lives inside a TS template literal.
+export const PAGE = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ship</title>
+<style>
+  :root { color-scheme: light dark; --fg: #1a1a1a; --bg: #fafaf8; --muted: #8a8a86; --card: #fff; --line: #e6e6e2; --accent: #0a7c42; --danger: #b3341f; }
+  @media (prefers-color-scheme: dark) { :root { --fg: #ececea; --bg: #131312; --muted: #8f8f8a; --card: #1c1c1b; --line: #2c2c2a; --accent: #3fb576; --danger: #e06a52; } }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--fg); font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  main { max-width: 640px; margin: 0 auto; padding: 32px 20px 120px; }
+  nav { display: flex; gap: 4px; margin-bottom: 24px; align-items: baseline; }
+  nav a { color: var(--muted); text-decoration: none; padding: 4px 10px; border-radius: 7px; font-weight: 500; }
+  nav a.active { color: var(--fg); background: var(--card); border: 1px solid var(--line); }
+  nav .brand { font-weight: 700; margin-right: 10px; }
+  #progress { margin-left: auto; color: var(--muted); font-variant-numeric: tabular-nums; }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 10px; padding: 24px; margin-bottom: 14px; }
+  .card.editing { border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent), 0 0 28px color-mix(in srgb, var(--accent) 10%, transparent); transition: box-shadow .2s, border-color .2s; }
+  .meta { display: flex; gap: 10px; align-items: center; margin-bottom: 16px; color: var(--muted); font-size: 13px; flex-wrap: wrap; }
+  .badge { border: 1px solid var(--line); border-radius: 99px; padding: 1px 10px; font-weight: 500; color: var(--fg); }
+  .score { font-variant-numeric: tabular-nums; }
+  .serif, textarea.grow { font: 17px/1.55 Georgia, "Times New Roman", serif; }
+  textarea.grow { width: 100%; border: none; background: none; color: inherit; resize: none; padding: 0; outline: none; display: block; }
+  #wrap { position: relative; }
+  #backdrop { position: absolute; inset: 0; pointer-events: none; white-space: pre-wrap; overflow-wrap: break-word; font: 17px/1.55 Georgia, "Times New Roman", serif; color: transparent; }
+  #backdrop mark { background: color-mix(in srgb, var(--accent) 28%, transparent); border-radius: 3px; color: transparent; }
+  #ask { display: none; margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--line); }
+  #ask.show { display: flex; gap: 8px; align-items: center; }
+  #ask input { flex: 1; border: 1px solid var(--line); background: var(--bg); color: inherit; border-radius: 7px; padding: 7px 12px; font: 14px -apple-system, sans-serif; outline: none; }
+  #ask input:focus { border-color: var(--accent); }
+  #ask .hint { color: var(--muted); font-size: 12px; white-space: nowrap; }
+  #ask.busy input { opacity: .5; pointer-events: none; }
+  footer { position: fixed; inset: auto 0 0 0; background: var(--bg); border-top: 1px solid var(--line); }
+  .keys { max-width: 640px; margin: 0 auto; padding: 14px 20px; display: flex; gap: 18px; color: var(--muted); font-size: 13px; }
+  kbd { border: 1px solid var(--line); border-bottom-width: 2px; border-radius: 5px; padding: 0 6px; font: 12px ui-monospace, monospace; color: var(--fg); }
+  #toast { position: fixed; top: 16px; left: 50%; transform: translateX(-50%); background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 8px 16px; font-size: 13px; opacity: 0; transition: opacity .15s; pointer-events: none; z-index: 10; }
+  #toast.show { opacity: 1; }
+  #toast a { color: var(--accent); }
+  .empty { text-align: center; color: var(--muted); padding: 60px 0; }
+  #chars { margin-left: auto; }
+  #chars.over { color: var(--danger); }
+  button.primary { background: var(--accent); color: #fff; border: none; border-radius: 7px; padding: 8px 16px; font: 500 14px -apple-system, sans-serif; cursor: pointer; }
+  button.primary:disabled { opacity: .5; cursor: default; }
+  button.ghost { background: none; color: var(--fg); border: 1px solid var(--line); border-radius: 7px; padding: 7px 14px; font: 500 14px -apple-system, sans-serif; cursor: pointer; }
+  button.ghost:hover { border-color: var(--muted); }
+  button.ghost.danger { color: var(--danger); }
+  .row { display: flex; gap: 10px; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--line); font-size: 14px; }
+  .row.tall { align-items: flex-start; }
+  .row .lines { flex: 1; min-width: 0; }
+  .row .lines .who { font-size: 13px; color: var(--muted); }
+  .row .lines .sum { font-size: 13px; color: var(--muted); font-style: italic; }
+  .row:last-child { border-bottom: none; }
+  .row .grow-cell { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .row .dim { color: var(--muted); font-size: 13px; }
+  .toolbar { display: flex; gap: 10px; align-items: center; margin-bottom: 16px; flex-wrap: wrap; }
+  .toolbar .spacer { flex: 1; }
+  pre.log { background: var(--card); border: 1px solid var(--line); border-radius: 10px; padding: 14px; font: 12px/1.6 ui-monospace, monospace; max-height: 320px; overflow-y: auto; white-space: pre-wrap; color: var(--muted); }
+  .tiles { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 14px; }
+  .tile { background: var(--card); border: 1px solid var(--line); border-radius: 10px; padding: 16px; }
+  .tile .n { font-size: 22px; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .tile .l { color: var(--muted); font-size: 12px; margin-top: 2px; }
+  .bar { height: 8px; background: var(--line); border-radius: 99px; overflow: hidden; margin-top: 8px; }
+  .bar > div { height: 100%; background: var(--accent); }
+  .tweet { border-left: 3px solid var(--line); padding-left: 12px; margin-bottom: 14px; }
+  .tweet .parent { color: var(--muted); font-size: 13px; border-left: 2px solid var(--line); padding-left: 10px; margin-bottom: 8px; }
+  .tweet a { color: inherit; text-decoration: none; }
+  .tweet .who { font-weight: 600; }
+  .tweet .stats { color: var(--muted); font-size: 13px; }
+  .actions { display: flex; gap: 10px; margin-top: 14px; }
+  .view { display: none; }
+  .view.active { display: block; }
+  input[type=checkbox] { accent-color: var(--accent); width: 15px; height: 15px; }
+</style>
+</head>
+<body>
+<main>
+  <nav>
+    <span class="brand">ship</span>
+    <a href="#generate" data-tab="generate">Generate</a>
+    <a href="#review" data-tab="review">Review</a>
+    <a href="#reply" data-tab="reply">Reply</a>
+    <a href="#stats" data-tab="stats">Stats</a>
+    <a href="#unfollow" data-tab="unfollow">Unfollow</a>
+    <span id="progress"></span>
+  </nav>
+
+  <section class="view" id="view-review">
+    <div class="card" id="card">
+      <div class="meta">
+        <span class="badge" id="platform"></span>
+        <span class="score" id="score"></span>
+        <span id="source"></span>
+        <span id="chars"></span>
+      </div>
+      <div id="wrap">
+        <div id="backdrop" aria-hidden="true"></div>
+        <textarea id="content" class="grow" spellcheck="true"></textarea>
+      </div>
+      <div id="ask">
+        <input id="askInput" placeholder="ask fable to change the selection…">
+        <span class="hint">⏎ rewrite · esc cancel</span>
+      </div>
+    </div>
+    <div class="empty" id="done" style="display:none">Queue clear. 🎉</div>
+  </section>
+
+  <section class="view" id="view-generate">
+    <div class="toolbar" id="genStatus" style="display:none">
+      <span class="dim" id="genStatusText" style="color:var(--muted);font-size:13px"></span>
+    </div>
+    <div class="card" id="genCard" style="display:none">
+      <div class="meta">
+        <span class="badge" id="genName"></span>
+        <span id="genWho"></span>
+        <span id="chars-gen" style="margin-left:auto" class="dim"></span>
+      </div>
+      <div id="genSummary" style="font-style:italic;color:var(--muted);margin-bottom:12px"></div>
+      <div id="genText" class="serif" style="max-height:340px;overflow-y:auto;white-space:pre-wrap;border-top:1px solid var(--line);padding-top:12px"></div>
+      <div class="actions">
+        <button class="primary" id="genProcess">Process</button>
+        <button class="ghost" id="genSkip">Skip</button>
+      </div>
+    </div>
+    <div class="empty" id="genDone" style="display:none">No transcripts waiting. 🎉</div>
+    <pre class="log" id="genLog" style="display:none"></pre>
+  </section>
+
+  <section class="view" id="view-reply">
+    <div class="toolbar">
+      <button class="primary" id="replyScan">Scan timeline</button>
+      <span class="dim" id="replyNote"></span>
+    </div>
+    <pre class="log" id="replyLog" style="display:none"></pre>
+    <div id="replyList"></div>
+  </section>
+
+  <section class="view" id="view-stats">
+    <div class="empty" id="statsLoading">Loading stats (X API can take a moment)…</div>
+    <div id="statsBody" style="display:none"></div>
+  </section>
+
+  <section class="view" id="view-unfollow">
+    <div class="toolbar">
+      <button class="primary" id="unfScan">Load candidates</button>
+      <span class="spacer"></span>
+      <button class="ghost" id="unfWhitelist" style="display:none">Whitelist selected</button>
+      <button class="ghost danger" id="unfRun" style="display:none">Unfollow selected</button>
+    </div>
+    <pre class="log" id="unfLog" style="display:none"></pre>
+    <div class="card" id="unfList" style="display:none"></div>
+  </section>
+</main>
+
+<footer>
+<div class="keys" id="keysReview">
+  <span><kbd>s</kbd> stage</span>
+  <span><kbd>r</kbd> reject</span>
+  <span><kbd>e</kbd> edit</span>
+  <span><kbd>k</kbd> skip</span>
+</div>
+<div class="keys" id="keysEdit" style="display:none">
+  <span><kbd>⌘s</kbd> stage</span>
+  <span>select text → <kbd>tab</kbd> ask fable</span>
+  <span><kbd>esc</kbd> done</span>
+</div>
+</footer>
+<div id="toast"></div>
+
+<script>
+const $ = (id) => document.getElementById(id);
+const escapeHtml = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const fmtN = (n) => n >= 1e6 ? (n / 1e6).toFixed(1) + 'M' : n >= 1e3 ? (n / 1e3).toFixed(1) + 'K' : String(n);
+
+function toast(html) {
+  $('toast').innerHTML = html;
+  $('toast').classList.add('show');
+  setTimeout(() => $('toast').classList.remove('show'), 2500);
+}
+
+async function api(method, path, body) {
+  const res = await fetch(path, {
+    method,
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || res.status);
+  return data;
+}
+
+function pollJob(name, logEl, onDone) {
+  const tick = async () => {
+    try {
+      const job = await api('GET', '/api/job/' + name);
+      if (logEl) {
+        logEl.style.display = 'block';
+        logEl.textContent = job.log.slice(-40).join('\\n');
+        logEl.scrollTop = logEl.scrollHeight;
+      }
+      if (job.running) setTimeout(tick, 1500);
+      else onDone(job);
+    } catch (e) {
+      toast('⚠️ ' + e.message);
+    }
+  };
+  tick();
+}
+
+// ── tabs ──────────────────────────────────────────────────────────────
+let activeTab = 'review';
+const tabInits = { review: false, generate: false, reply: false, stats: false, unfollow: false };
+
+function showTab(name) {
+  activeTab = name;
+  document.querySelectorAll('.view').forEach((v) => v.classList.remove('active'));
+  document.querySelectorAll('nav a').forEach((a) => a.classList.toggle('active', a.dataset.tab === name));
+  $('view-' + name).classList.add('active');
+  $('progress').textContent = '';
+  document.querySelector('footer').style.display = name === 'review' ? 'block' : 'none';
+  if (!tabInits[name]) {
+    tabInits[name] = true;
+    ({ review: initReview, generate: initGenerate, reply: initReply, stats: initStats, unfollow: initUnfollow })[name]();
+  } else if (name === 'review') {
+    showPost();
+  } else if (name === 'generate') {
+    showTranscript();
+  }
+}
+window.addEventListener('hashchange', () => showTab(location.hash.slice(1) || 'review'));
+
+// ── review ────────────────────────────────────────────────────────────
+let queue = [], idx = 0, busy = false, sel = null;
+
+function initReview() {
+  api('GET', '/api/posts').then((d) => { queue = d.posts; showPost(); }).catch((e) => toast('⚠️ ' + e.message));
+}
+
+function showPost() {
+  if (activeTab !== 'review') return;
+  const p = queue[idx];
+  if (!p) { $('card').style.display = 'none'; $('done').style.display = 'block'; $('progress').textContent = ''; return; }
+  $('card').style.display = 'block';
+  $('done').style.display = 'none';
+  $('platform').textContent = p.platform === 'linkedin' ? 'LinkedIn' : 'X';
+  $('score').textContent = p.score ? (p.score >= 70 ? '🔥 ' : '') + p.score + '/99' : 'no score';
+  $('source').textContent = p.sourceFile.replace(/^input\\//, '').replace(/\\.txt$/, '');
+  const draft = localStorage.getItem('draft:' + p.id);
+  $('content').value = draft !== null ? draft : p.content;
+  $('progress').textContent = (queue.length - idx) + ' remaining';
+  hideAsk();
+  updateChars();
+  autosize($('content'));
+  $('content').blur();
+}
+
+function autosize(el) {
+  el.style.height = 'auto';
+  el.style.height = el.scrollHeight + 'px';
+}
+
+function updateChars() {
+  const p = queue[idx];
+  if (!p) return;
+  const n = $('content').value.length;
+  $('chars').textContent = n + (p.platform === 'x' ? ' / 280' : '');
+  $('chars').className = p.platform === 'x' && n > 280 ? 'over' : '';
+}
+
+async function decide(action) {
+  if (busy || activeTab !== 'review') return;
+  const p = queue[idx];
+  if (!p) return;
+  busy = true;
+  try {
+    const body = await api('POST', '/api/decision', { id: p.id, action, content: $('content').value });
+    localStorage.removeItem('draft:' + p.id);
+    toast(action === 'stage'
+      ? (body.share_url ? 'Staged → <a href="' + body.share_url + '" target="_blank">Typefully</a>' : 'Staged → Typefully')
+      : 'Rejected');
+    queue.splice(idx, 1);
+    showPost();
+  } catch (e) { toast('⚠️ ' + e.message); }
+  busy = false;
+}
+
+function paintSelection() {
+  if (!sel) { $('backdrop').innerHTML = ''; return; }
+  const v = $('content').value;
+  $('backdrop').innerHTML =
+    escapeHtml(v.slice(0, sel.start)) + '<mark>' + escapeHtml(v.slice(sel.start, sel.end)) + '</mark>' + escapeHtml(v.slice(sel.end));
+}
+
+function checkSelection() {
+  const c = $('content');
+  if (document.activeElement !== c) return;
+  if (c.selectionEnd > c.selectionStart) {
+    sel = { start: c.selectionStart, end: c.selectionEnd };
+    $('ask').classList.add('show');
+    paintSelection();
+  } else if (sel) {
+    hideAsk();
+  }
+}
+
+function hideAsk() {
+  $('ask').classList.remove('show', 'busy');
+  $('askInput').value = '';
+  sel = null;
+  paintSelection();
+}
+
+async function askFable() {
+  const p = queue[idx];
+  const instruction = $('askInput').value.trim();
+  if (!p || !sel || !instruction) return;
+  $('ask').classList.add('busy');
+  try {
+    const body = await api('POST', '/api/rewrite', {
+      content: $('content').value, start: sel.start, end: sel.end, instruction, platform: p.platform,
+    });
+    const c = $('content');
+    const v = c.value;
+    c.value = v.slice(0, sel.start) + body.replacement + v.slice(sel.end);
+    const end = sel.start + body.replacement.length;
+    hideAsk();
+    updateChars();
+    autosize(c);
+    localStorage.setItem('draft:' + p.id, c.value);
+    c.focus();
+    c.setSelectionRange(end, end);
+    toast('✨ rewritten');
+  } catch (e) {
+    toast('⚠️ ' + e.message);
+    $('ask').classList.remove('busy');
+  }
+}
+
+function setEditing(on) {
+  $('card').classList.toggle('editing', on);
+  $('keysReview').style.display = on ? 'none' : 'flex';
+  $('keysEdit').style.display = on ? 'flex' : 'none';
+}
+
+document.addEventListener('keydown', (e) => {
+  if (activeTab === 'generate' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    if (e.key === 'p') processTranscript();
+    else if (e.key === 'k') skipTranscript();
+    return;
+  }
+  if (activeTab !== 'review') return;
+  if ((e.metaKey || e.ctrlKey) && e.key === 's') { e.preventDefault(); decide('stage'); return; }
+  if ((e.metaKey || e.ctrlKey) && e.key === 'r' && e.shiftKey) { e.preventDefault(); decide('reject'); return; }
+  if (e.metaKey || e.ctrlKey || e.altKey) return;
+  if (document.activeElement === $('askInput')) {
+    if (e.key === 'Enter') askFable();
+    else if (e.key === 'Escape') { hideAsk(); $('content').focus(); }
+    return;
+  }
+  const editing = document.activeElement === $('content');
+  if (editing) {
+    if (e.key === 'Escape') {
+      if ($('ask').classList.contains('show')) hideAsk();
+      else $('content').blur();
+    } else if (e.key === 'Tab' && $('ask').classList.contains('show')) {
+      e.preventDefault();
+      $('askInput').focus();
+    }
+    return;
+  }
+  if (e.key === 's') decide('stage');
+  else if (e.key === 'r') decide('reject');
+  else if (e.key === 'k') { idx = (idx + 1) % Math.max(queue.length, 1); showPost(); }
+  else if (e.key === 'e') { e.preventDefault(); $('content').focus(); }
+});
+
+$('content').addEventListener('select', checkSelection);
+$('content').addEventListener('mouseup', checkSelection);
+$('content').addEventListener('focus', () => setEditing(true));
+$('askInput').addEventListener('focus', () => setEditing(true));
+$('content').addEventListener('blur', (e) => { if (e.relatedTarget !== $('askInput')) setEditing(false); });
+$('askInput').addEventListener('blur', (e) => { if (e.relatedTarget !== $('content')) setEditing(false); });
+$('content').addEventListener('input', () => {
+  if (sel) hideAsk(); // typing/deleting invalidates the selection and its highlight
+  updateChars();
+  autosize($('content'));
+  const p = queue[idx];
+  if (p) {
+    if ($('content').value !== p.content) localStorage.setItem('draft:' + p.id, $('content').value);
+    else localStorage.removeItem('draft:' + p.id);
+  }
+});
+
+// ── generate ──────────────────────────────────────────────────────────
+let gqueue = [], gpolling = false;
+
+function initGenerate() {
+  api('GET', '/api/transcripts').then((d) => {
+    gqueue = d.transcripts;
+    showTranscript();
+  }).catch((e) => toast('⚠️ ' + e.message));
+  $('genProcess').onclick = processTranscript;
+  $('genSkip').onclick = skipTranscript;
+  watchGenerate(); // pick up any batch already running server-side
+}
+
+async function showTranscript() {
+  const t = gqueue[0];
+  if (activeTab === 'generate') $('progress').textContent = t ? gqueue.length + ' waiting' : '';
+  if (!t) {
+    $('genCard').style.display = 'none';
+    $('genDone').style.display = 'block';
+    return;
+  }
+  $('genCard').style.display = 'block';
+  $('genDone').style.display = 'none';
+  $('genName').textContent = t.name.replace(/\\.(txt|md)$/, '');
+  $('genWho').textContent = t.attendees.length ? 'with ' + t.attendees.join(', ') : '';
+  $('chars-gen').textContent = fmtN(t.size) + 'b';
+  $('genSummary').textContent = t.summary || '…';
+  $('genText').textContent = '';
+  if (!t.summary) {
+    api('POST', '/api/transcripts/summary', { name: t.name })
+      .then((r) => { if (gqueue[0] === t) { t.summary = r.summary; $('genSummary').textContent = r.summary; } })
+      .catch(() => { if (gqueue[0] === t) $('genSummary').textContent = ''; });
+  }
+  api('GET', '/api/transcripts/content?name=' + encodeURIComponent(t.name))
+    .then((r) => { if (gqueue[0] === t) $('genText').textContent = r.content; })
+    .catch(() => {});
+}
+
+function processTranscript() {
+  const t = gqueue[0];
+  if (!t) return;
+  api('POST', '/api/generate', { files: [t.name] }).then(() => {
+    toast('Processing ' + t.name.replace(/\\.(txt|md)$/, ''));
+    gqueue.shift();
+    showTranscript();
+    watchGenerate();
+    tabInits.review = false; // refresh review queue next visit
+  }).catch((e) => toast('⚠️ ' + e.message));
+}
+
+function skipTranscript() {
+  const t = gqueue[0];
+  if (!t) return;
+  api('POST', '/api/transcripts/skip', { name: t.name }).then(() => {
+    gqueue.shift();
+    showTranscript();
+  }).catch((e) => toast('⚠️ ' + e.message));
+}
+
+function watchGenerate() {
+  if (gpolling) return;
+  gpolling = true;
+  const tick = async () => {
+    try {
+      const s = await api('GET', '/api/generate/status');
+      if (s.running) {
+        $('genStatus').style.display = 'flex';
+        const name = s.active ? s.active.replace(/\\.(txt|md)$/, '') : '…';
+        $('genStatusText').textContent = '⚙︎ processing ' + name + (s.queued ? ' · ' + s.queued + ' queued' : '') + ' — ' + s.lastLine;
+        setTimeout(tick, 2000);
+      } else {
+        gpolling = false;
+        if ($('genStatus').style.display !== 'none') {
+          $('genStatusText').textContent = s.error ? '⚠️ ' + s.error : '✓ batch done — new posts in Review';
+          tabInits.review = false;
+        }
+      }
+    } catch { gpolling = false; }
+  };
+  tick();
+}
+
+// ── reply ─────────────────────────────────────────────────────────────
+function initReply() {
+  $('replyScan').onclick = () => {
+    $('replyScan').disabled = true;
+    $('replyList').innerHTML = '';
+    api('POST', '/api/reply/scan').then(() => {
+      pollJob('reply', $('replyLog'), (job) => {
+        $('replyScan').disabled = false;
+        $('replyLog').style.display = 'none';
+        if (job.error) { toast('⚠️ ' + job.error); return; }
+        renderReplies(job.result.opportunities);
+      });
+    }).catch((e) => { toast('⚠️ ' + e.message); $('replyScan').disabled = false; });
+  };
+}
+
+function renderReplies(opps) {
+  if (!opps.length) {
+    $('replyList').innerHTML = '<div class="empty">No good reply opportunities right now.</div>';
+    return;
+  }
+  $('replyNote').textContent = opps.length + ' opportunities';
+  $('replyList').innerHTML = opps.map((o, i) =>
+    '<div class="card" data-i="' + i + '">' +
+    '<div class="tweet">' +
+    (o.parentText ? '<div class="parent">@' + escapeHtml(o.parentAuthor || '') + ': ' + escapeHtml(o.parentText) + '</div>' : '') +
+    '<div><a href="' + escapeHtml(o.url) + '" target="_blank"><span class="who">@' + escapeHtml(o.author) + '</span></a>' +
+    ' <span class="stats">' + fmtN(o.followers) + ' followers · ♥ ' + fmtN(o.likes) + ' · 💬 ' + fmtN(o.replies) + '</span></div>' +
+    '<div class="serif">' + escapeHtml(o.text) + '</div>' +
+    '</div>' +
+    '<textarea class="grow reply-text" spellcheck="true">' + escapeHtml(o.suggestedReply) + '</textarea>' +
+    '<div class="actions">' +
+    '<button class="primary reply-post">Post + like</button>' +
+    '<button class="ghost reply-skip">Skip</button>' +
+    '<span class="dim" style="align-self:center">' + escapeHtml(o.reasoning || '') + '</span>' +
+    '</div></div>'
+  ).join('');
+  document.querySelectorAll('#replyList .reply-text').forEach((t) => {
+    autosize(t);
+    t.addEventListener('input', () => autosize(t));
+  });
+  document.querySelectorAll('#replyList .reply-post').forEach((btn) => btn.addEventListener('click', async (e) => {
+    const card = e.target.closest('.card');
+    const o = opps[+card.dataset.i];
+    btn.disabled = true;
+    try {
+      const r = await api('POST', '/api/reply/post', { tweetId: o.tweetId, text: card.querySelector('.reply-text').value });
+      toast('Posted → <a href="' + r.url + '" target="_blank">view</a>');
+      card.remove();
+    } catch (err) { toast('⚠️ ' + err.message); btn.disabled = false; }
+  }));
+  document.querySelectorAll('#replyList .reply-skip').forEach((btn) => btn.addEventListener('click', async (e) => {
+    const card = e.target.closest('.card');
+    const o = opps[+card.dataset.i];
+    try {
+      await api('POST', '/api/reply/skip', { tweetId: o.tweetId });
+      card.remove();
+    } catch (err) { toast('⚠️ ' + err.message); }
+  }));
+}
+
+// ── stats ─────────────────────────────────────────────────────────────
+function initStats() {
+  api('GET', '/api/stats').then((s) => {
+    $('statsLoading').style.display = 'none';
+    $('statsBody').style.display = 'block';
+    const pct = Math.min(100, Math.round((s.goal.projected / s.goal.target) * 100));
+    const tile = (n, l) => '<div class="tile"><div class="n">' + n + '</div><div class="l">' + l + '</div></div>';
+    $('statsBody').innerHTML =
+      '<div class="tiles">' +
+      tile(fmtN(s.account ? s.account.followers : 0), '@' + escapeHtml(s.username) + ' followers') +
+      tile(fmtN(s.d7.impressions), 'impressions · 7d') +
+      tile(s.d7.posts, 'posts · 7d') +
+      tile(fmtN(s.d7.likes), 'likes · 7d') +
+      tile(fmtN(s.d7.replies), 'replies · 7d') +
+      tile(s.d7.engagementRate.toFixed(2) + '%', 'engagement · 7d') +
+      '</div>' +
+      '<div class="card"><div class="meta"><span class="badge">90-day goal</span><span>' + fmtN(s.goal.projected) + ' projected of ' + fmtN(s.goal.target) + '</span></div>' +
+      '<div class="bar"><div style="width:' + pct + '%"></div></div>' +
+      '<div class="dim" style="margin-top:8px;color:var(--muted);font-size:13px">' + fmtN(s.goal.dailyAvg) + '/day now · best hours: ' +
+      s.bestHours.map((h) => (h % 12 || 12) + (h >= 12 ? 'PM' : 'AM')).join(', ') + '</div></div>' +
+      (s.topPost
+        ? '<div class="card"><div class="meta"><span class="badge">top post · 7d</span><span>' + fmtN(s.topPost.impressions) + ' imp · ♥ ' + fmtN(s.topPost.likes) + '</span></div>' +
+          '<div class="serif">' + escapeHtml(s.topPost.text) + '</div></div>'
+        : '') +
+      (s.cached ? '<div class="empty" style="padding:10px">cached · refreshes hourly</div>' : '');
+  }).catch((e) => {
+    $('statsLoading').textContent = '⚠️ ' + e.message;
+  });
+}
+
+// ── unfollow ──────────────────────────────────────────────────────────
+function initUnfollow() {
+  $('unfScan').onclick = () => {
+    $('unfScan').disabled = true;
+    api('POST', '/api/unfollow/scan').then(() => {
+      pollJob('unfollow-scan', $('unfLog'), (job) => {
+        $('unfScan').disabled = false;
+        $('unfLog').style.display = 'none';
+        if (job.error) { toast('⚠️ ' + job.error); return; }
+        renderUnfollow(job.result);
+        $('unfScan').textContent = 'Refresh candidates';
+      });
+    }).catch((e) => { toast('⚠️ ' + e.message); $('unfScan').disabled = false; });
+  };
+  $('unfWhitelist').onclick = () => {
+    const boxes = [...document.querySelectorAll('#unfList input:checked')];
+    if (!boxes.length) return;
+    const entries = boxes.map((b) => ({ id: b.value, username: b.closest('.row').querySelector('b').textContent.slice(1) }));
+    api('POST', '/api/unfollow/whitelist', { entries }).then(() => {
+      boxes.forEach((b) => b.closest('.row').remove());
+      toast('Whitelisted ' + entries.length + ' — never suggested again');
+    }).catch((e) => toast('⚠️ ' + e.message));
+  };
+  $('unfScan').click(); // auto-load from the cached following list
+  $('unfRun').onclick = () => {
+    const boxes = [...document.querySelectorAll('#unfList input:checked')];
+    if (!boxes.length) return;
+    const entries = boxes.map((b) => ({ id: b.value, username: b.closest('.row').querySelector('b').textContent.slice(1) }));
+    boxes.forEach((b) => {
+      const mark = document.createElement('span');
+      mark.textContent = '✓';
+      mark.style.cssText = 'color:var(--accent);width:15px;text-align:center;font-weight:700';
+      b.replaceWith(mark);
+      mark.closest('.row').style.opacity = '0.55';
+    });
+    api('POST', '/api/unfollow/run', { entries }).then((r) => {
+      toast('Held ' + entries.length + ' unfollow decision' + (entries.length === 1 ? '' : 's') + ' (' + r.pending + ' pending)');
+      watchUnfollow();
+    }).catch((e) => toast('⚠️ ' + e.message));
+  };
+}
+
+let unfPolling = false;
+function watchUnfollow() {
+  if (unfPolling) return;
+  unfPolling = true;
+  const tick = async () => {
+    try {
+      const job = await api('GET', '/api/job/unfollow-run');
+      const last = job.log.filter((l) => l.trim()).slice(-1)[0] || '';
+      $('unfLog').style.display = 'block';
+      $('unfLog').textContent = job.running ? '⚙︎ ' + last : (job.error ? '⚠️ ' + job.error : '✓ ' + last);
+      if (job.running) setTimeout(tick, 2000);
+      else unfPolling = false;
+    } catch { unfPolling = false; }
+  };
+  tick();
+}
+
+function renderUnfollow(result) {
+  $('unfList').style.display = 'block';
+  $('unfRun').style.display = 'inline-block';
+  $('unfWhitelist').style.display = 'inline-block';
+  $('replyNote').textContent = '';
+  if (!result.candidates.length) {
+    $('unfList').innerHTML = '<div class="empty">No unfollow candidates — following ' + result.followingCount + ' accounts.</div>';
+    return;
+  }
+  const pendingHtml = result.pendingCount
+    ? '<span>· ' + result.pendingCount + ' pending <a href="#" id="unfRetry" style="color:var(--accent)">retry</a></span>'
+    : '';
+  $('unfList').innerHTML =
+    '<div class="meta"><span class="badge">following ' + result.followingCount + '</span><span>' + result.candidates.length + ' candidates (worst first)</span>' + pendingHtml + '</div>' +
+    result.candidates.map((c) => {
+      const reason = c.reason.split(', ').filter((r) => !/followers$/.test(r) && !/tweets \\(inactive\\)$/.test(r)).join(', ');
+      return '<label class="row tall" style="padding:12px 0"><input type="checkbox" value="' + escapeHtml(c.id) + '">' +
+      '<span class="lines">' +
+      '<div><a href="https://x.com/' + escapeHtml(c.username) + '" target="_blank" style="color:inherit"><b>@' + escapeHtml(c.username) + '</b></a> <span class="who">' + escapeHtml(c.name) + '</span></div>' +
+      '<div class="who">' + fmtN(c.followers) + ' followers · ' + fmtN(c.tweets) + ' posts' + (reason ? ' · ' + escapeHtml(reason) : '') + '</div>' +
+      '</span></label>';
+    }).join('');
+  const retry = $('unfRetry');
+  if (retry) retry.onclick = (e) => {
+    e.preventDefault();
+    api('POST', '/api/unfollow/retry').then(() => { toast('Retrying pending unfollows'); watchUnfollow(); })
+      .catch((err) => toast('⚠️ ' + err.message));
+  };
+}
+
+// ── boot ──────────────────────────────────────────────────────────────
+showTab(location.hash.slice(1) || 'review');
+</script>
+</body>
+</html>`;

--- a/src/commands/unfollow.ts
+++ b/src/commands/unfollow.ts
@@ -11,8 +11,26 @@ import { formatFollowerCount } from '../utils/format.js';
 
 const FOLLOWING_CACHE_FILE = '.shippost-following-cache.json';
 const FOLLOWING_CACHE_MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
+const WHITELIST_FILE = '.shippost-unfollow-whitelist.json';
 
-interface FollowingAccount {
+/** Accounts never suggested for unfollow, id → username (username is for human readability of the file). */
+export function loadWhitelist(cwd: string): Record<string, string> {
+  const file = join(cwd, WHITELIST_FILE);
+  if (!existsSync(file)) return {};
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+export function addToWhitelist(cwd: string, entries: { id: string; username: string }[]): void {
+  const list = loadWhitelist(cwd);
+  for (const e of entries) list[e.id] = e.username;
+  writeFileSync(join(cwd, WHITELIST_FILE), JSON.stringify(list, null, 2));
+}
+
+export interface FollowingAccount {
   id: string;
   username: string;
   name: string;
@@ -20,9 +38,10 @@ interface FollowingAccount {
   followingCount: number;
   tweetCount: number;
   followsBack: boolean;
+  bio?: string;
 }
 
-function loadFollowingCache(cwd: string): FollowingAccount[] | null {
+export function loadFollowingCache(cwd: string): FollowingAccount[] | null {
   const cacheFile = join(cwd, FOLLOWING_CACHE_FILE);
   if (!existsSync(cacheFile)) return null;
   try {
@@ -36,12 +55,12 @@ function loadFollowingCache(cwd: string): FollowingAccount[] | null {
   }
 }
 
-function saveFollowingCache(cwd: string, accounts: FollowingAccount[]): void {
+export function saveFollowingCache(cwd: string, accounts: FollowingAccount[]): void {
   const cacheFile = join(cwd, FOLLOWING_CACHE_FILE);
   writeFileSync(cacheFile, JSON.stringify({ timestamp: Date.now(), accounts }, null, 2));
 }
 
-function removeFromCache(cwd: string, userId: string): void {
+export function removeFromCache(cwd: string, userId: string): void {
   const accounts = loadFollowingCache(cwd);
   if (!accounts) return;
   const filtered = accounts.filter((a) => a.id !== userId);
@@ -57,7 +76,7 @@ interface UnfollowOptions {
   yes?: boolean;
 }
 
-interface UnfollowCandidate {
+export interface UnfollowCandidate {
   id: string;
   username: string;
   name: string;
@@ -68,7 +87,7 @@ interface UnfollowCandidate {
   reason: string;
 }
 
-function buildCandidates(
+export function buildCandidates(
   following: Array<{ id: string; username: string; name: string; followersCount: number; followingCount: number; tweetCount: number; followsBack: boolean }>,
   options: UnfollowOptions
 ): UnfollowCandidate[] {
@@ -91,11 +110,20 @@ function buildCandidates(
       ? (account.tweetCount / account.followersCount) * 1000
       : account.tweetCount > 0 ? 9999 : 0;
 
+    // Spammy = posts tons AND nobody follows. High volume with a real
+    // audience is just a prolific poster, not spam.
+    const isSpammy = tweetsPerKFollowers > 1000 && account.followersCount < 2000;
+    // Follow farmer: follows thousands, almost nobody follows back
+    const isFarmer =
+      account.followingCount > 2000 &&
+      account.followingCount > 5 * Math.max(account.followersCount, 1);
+
     const isLowQuality =
       account.tweetCount < 10 ||                           // inactive
       account.followersCount < minFollowers ||              // low reach
       tweetsPerKFollowers < 1 ||                            // dead account (has followers but doesn't post)
-      tweetsPerKFollowers > 1000;                           // spammy (posts tons, nobody follows)
+      isSpammy ||
+      isFarmer;
 
     if (options.inactive) {
       if (account.tweetCount < 10) {
@@ -105,8 +133,11 @@ function buildCandidates(
       // Add quality context to reason
       if (tweetsPerKFollowers < 1 && account.followersCount >= minFollowers) {
         reasons.push('dead account');
-      } else if (tweetsPerKFollowers > 1000) {
+      } else if (isSpammy) {
         reasons.push('spammy ratio');
+      }
+      if (isFarmer) {
+        reasons.push('follow farmer');
       }
       candidates.push({ ...account, reason: reasons.join(', ') || 'low quality' });
     }
@@ -198,7 +229,8 @@ export async function unfollowCommand(options: UnfollowOptions): Promise<void> {
         break;
       }
 
-      const candidates = buildCandidates(following, options);
+      const whitelist = loadWhitelist(cwd);
+      const candidates = buildCandidates(following, options).filter((c) => !whitelist[c.id]);
 
       // How many to unfollow this round
       let batchSize = options.batch || 50;

--- a/src/commands/work.ts
+++ b/src/commands/work.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, statSync, existsSync, mkdirSync, writeFileSync } from 'fs';
-import { join, relative } from 'path';
+import { join, relative, basename } from 'path';
 import { FileSystemService } from '../services/file-system.js';
 import { createLLMService } from '../services/llm-factory.js';
 import { ContentAnalyzer } from '../services/content-analyzer.js';
@@ -26,6 +26,7 @@ interface WorkOptions {
   category?: string;
   noStrategies?: boolean;
   all?: boolean;
+  files?: string;
 }
 
 function buildPrompt(systemPrompt: string, styleGuide: string, workInstructions: string, transcript: string): string {
@@ -71,7 +72,7 @@ function parsePostsFromResponse(response: string): PostGenerationResult[] {
           platform = undefined;
         }
 
-        return { content, platform };
+        return { content: stripEmDashes(content), platform };
       })
       .filter((item) => {
         const content = item.content;
@@ -215,16 +216,36 @@ function bodyLinksToPublished(body: string, knownSlugs: Set<string>): boolean {
   return false;
 }
 
+// Site rule: generated essays must contain zero em dashes (rywalker.com lint
+// allows at most one per essay, and that one is reserved for human edits).
+// The prompt forbids them; this is the mechanical backstop for any that slip
+// through.
+function stripEmDashes(s: string): string {
+  return s.replace(/[ \t]*—[ \t]*/g, ', ');
+}
+
 function normalizeBlogResult(e: any): BlogGenerationResult {
   return {
-    title: e.title || 'Untitled Blog Draft',
+    title: stripEmDashes(e.title || 'Untitled Blog Draft'),
     slug: e.slug || createSlug(e.title || 'untitled'),
-    description: e.description || '',
+    description: stripEmDashes(e.description || ''),
     tags: Array.isArray(e.tags) ? e.tags : ['ai'],
-    takeaways: Array.isArray(e.takeaways) ? e.takeaways : [],
-    faq: Array.isArray(e.faq) ? e.faq : [],
+    takeaways: Array.isArray(e.takeaways)
+      ? e.takeaways.map((t: any) => (typeof t === 'string' ? stripEmDashes(t) : t))
+      : [],
+    faq: Array.isArray(e.faq)
+      ? e.faq.map((f: any) =>
+          f && typeof f === 'object'
+            ? {
+                ...f,
+                question: typeof f.question === 'string' ? stripEmDashes(f.question) : f.question,
+                answer: typeof f.answer === 'string' ? stripEmDashes(f.answer) : f.answer,
+              }
+            : f
+        )
+      : [],
     sources: Array.isArray(e.sources) ? e.sources : [],
-    body: (e.body || '').replace(/\\n/g, '\n'),
+    body: stripEmDashes((e.body || '').replace(/\\n/g, '\n')),
     motif: typeof e.motif === 'string' ? e.motif : '',
     accent: typeof e.accent === 'string' ? e.accent : undefined,
     accent2: typeof e.accent2 === 'string' ? e.accent2 : undefined,
@@ -278,6 +299,11 @@ SHAPE OF EACH POST (this is the most important constraint):
 - 3-5 short paragraphs. NO ## section headers. The post is itself one section.
 - Open with the claim or a sharp hook. Close with a forward-looking line or a "what to do" pivot.
 - Cut everything that does not directly support the single argument.
+
+HARD BANS (site lint rejects violations, so these are non-negotiable):
+- NO em dashes (—) anywhere: not in the body, title, description, takeaways, or FAQ. Use a comma, colon, or period, or restructure the sentence.
+- NO stock AI phrasings. Never write "the thing nobody says out loud" (or any nobody/no one ... out loud variant), never "saying the quiet part out loud". If a phrase reads like a viral-post template, cut it.
+- Follow the Confidentiality and Sensitivity Guardrails in the style guide exactly: no identifiable customers, prospects, or live deals; no weak internal traction or metrics admissions; no internal pricing or services-playbook numbers; no other companies' private info from conversations; no AI-leads-to-layoffs framing; no condescension toward buyers; team members are spoken of positively or left out.
 
 Output ONLY valid JSON (no markdown fences, no commentary) with this exact structure:
 {
@@ -526,7 +552,17 @@ ${content}
 
 Does this post need updating based on the new transcript content? If yes, respond with ONLY the updated file content — start with the --- frontmatter delimiter, no preamble, no commentary, no markdown fences. If no, respond with exactly "SKIP".
 
-Only update if the transcript content is genuinely related and would improve the post. Preserve all existing frontmatter fields and formatting exactly.`;
+Only update if the transcript content is genuinely related and would improve the post. Preserve all existing frontmatter fields and formatting exactly.
+
+SHAPE CONSTRAINTS (strict — these are short atomic posts):
+- ONE argument per post. 250-450 words in the body, hard cap at 500. NO ## section headers.
+- An update must NOT grow the post. Refine wording, correct facts, sharpen the argument — never append new sections, paragraphs of new material, new takeaways, or new FAQ entries.
+- Keep the existing takeaways count (3) and faq count (2). Do not add entries.
+- If the post is already over 500 body words, an acceptable update may shorten it, never lengthen it.
+- If the transcript contains a NEW argument related to this post's topic, respond "SKIP" — new arguments become new atomic posts, not additions to existing ones.
+- NO em dashes (—) in any text you write. If a sentence you are rewording contains one, replace it with a comma, colon, or period. Site lint allows at most one em dash per essay.
+- NO stock AI phrasings like "the thing nobody says out loud" or "saying the quiet part out loud". Site lint rejects them.
+- NO confidential material from the transcript: no customer- or prospect-identifying details, no weak internal traction or metrics admissions, no internal pricing or margin numbers, no other companies' private info, no AI-leads-to-layoffs framing, and no negative or unverified mentions of team members. Generalize the pattern; drop the specifics.`;
 
       const response = await llm.generate(prompt);
 
@@ -688,7 +724,11 @@ export async function workCommand(options: WorkOptions): Promise<void> {
     logger.info(`Strategy-based generation enabled (${postCount} posts per file)`);
   }
 
-  const inputFiles = findInputFiles(join(cwd, 'input'));
+  let inputFiles = findInputFiles(join(cwd, 'input'));
+  if (options.files) {
+    const wanted = new Set(options.files.split(',').map((f) => f.trim()).filter(Boolean));
+    inputFiles = inputFiles.filter((f) => wanted.has(basename(f)));
+  }
   if (inputFiles.length === 0) {
     logger.error('No input files found in input/ directory');
     logger.info('Add .txt or .md files to input/ and try again');

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { initCommand } from './commands/init.js';
 import { workCommand } from './commands/work.js';
 import { postsCommand } from './commands/posts.js';
 import { reviewCommand } from './commands/review.js';
+import { uiCommand } from './commands/ui/index.js';
 import { analyzeXCommand } from './commands/analyze-x.js';
 import { replyCommand } from './commands/reply.js';
 import { xStatusCommand } from './commands/x-status.js';
@@ -53,6 +54,7 @@ program
   .option('--category <category>', 'Filter strategies by category (with --list-strategies)')
   .option('--no-strategies', 'Disable strategy-based generation (use legacy mode)')
   .option('-a, --all', 'Process all transcripts without prompting')
+  .option('--files <names>', 'Only process these input files (comma-separated basenames)')
   .action(workCommand);
 
 program
@@ -69,7 +71,16 @@ program
   .command('review')
   .description('Review posts one-by-one and mark as keep/reject')
   .option('--min-score <score>', 'Only review posts with score >= N', parseInt)
-  .action(reviewCommand);
+  .option('--web', 'Review in the local web UI instead of the terminal')
+  .option('--port <port>', 'Port for --web (default: 4747)', parseInt)
+  .action((opts) => (opts.web ? uiCommand(opts) : reviewCommand(opts)));
+
+program
+  .command('ui')
+  .description('Local web UI: review, generate, reply, stats, unfollow')
+  .option('--port <port>', 'Port (default: 4747)', parseInt)
+  .option('--min-score <score>', 'Only show review posts with score >= N', parseInt)
+  .action(uiCommand);
 
 program
   .command('analyze-x')

--- a/src/services/anthropic.ts
+++ b/src/services/anthropic.ts
@@ -81,7 +81,10 @@ export class AnthropicService implements LLMService {
       const response = await this.client.messages.create({
         model: this.getModelName(),
         max_tokens: this.config.anthropic?.maxTokens || 4096,
-        temperature: this.config.generation.temperature || 0.7,
+        // Fable 5 and Opus 4.7+ reject sampling params (400)
+        ...(this.supportsTemperature()
+          ? { temperature: this.config.generation.temperature || 0.7 }
+          : {}),
         messages: [
           {
             role: 'user',
@@ -111,5 +114,10 @@ export class AnthropicService implements LLMService {
 
   getTemperature(): number {
     return this.config.generation.temperature || 0.7;
+  }
+
+  supportsTemperature(): boolean {
+    const model = this.getModelName();
+    return !/^claude-(fable|mythos)-|^claude-opus-4-[7-9]/.test(model);
   }
 }

--- a/src/services/x-api.ts
+++ b/src/services/x-api.ts
@@ -90,6 +90,23 @@ export class XApiService {
   /**
    * Look up a user by username
    */
+  /** Bulk user lookup with bios and metrics — 100 ids per API call. */
+  async getUsersByIds(ids: string[]): Promise<UserV2[]> {
+    const out: UserV2[] = [];
+    for (let i = 0; i < ids.length; i += 100) {
+      const batch = ids.slice(i, i + 100);
+      try {
+        const { data } = await this.client.v2.users(batch, {
+          'user.fields': ['description', 'public_metrics'],
+        });
+        if (Array.isArray(data)) out.push(...data);
+      } catch (error) {
+        handleApiError(error as TwitterApiError, 'Failed to look up users');
+      }
+    }
+    return out;
+  }
+
   async getUserByUsername(username: string): Promise<UserV2> {
     try {
       const { data } = await this.client.v2.userByUsername(username);
@@ -574,6 +591,7 @@ export class XApiService {
     tweetCount: number;
     followsBack: boolean;
     lastTweetAt?: string;
+    bio?: string;
   }>> {
     const me = await this.getMe();
     const results: Array<{
@@ -585,6 +603,7 @@ export class XApiService {
       tweetCount: number;
       followsBack: boolean;
       lastTweetAt?: string;
+      bio?: string;
     }> = [];
 
     try {
@@ -593,7 +612,7 @@ export class XApiService {
       do {
         const response = await this.client.v2.following(me.id, {
           max_results: 100,
-          'user.fields': ['public_metrics', 'created_at'],
+          'user.fields': ['public_metrics', 'created_at', 'description'],
           ...(nextToken ? { pagination_token: nextToken } : {}),
         });
 
@@ -610,6 +629,7 @@ export class XApiService {
             followingCount: metrics?.following_count || 0,
             tweetCount: metrics?.tweet_count || 0,
             followsBack: followerIds ? followerIds.has(user.id) : false,
+            bio: user.description || '',
           });
 
           if (results.length >= maxResults) return results;


### PR DESCRIPTION
## What

New `ship ui` command: a local web app (port 4747) covering the whole shippost workflow in five tabs, replacing the terminal-interactive flows for daily use. `ship review --web` opens the same app.

### Generate
- Card per transcript: attendees (from Granola calendar data), cached Haiku one-line summary, full transcript text
- **Process** / **Skip** (`p`/`k`) — skips persist; Process queues sequential `ship work --all --files <name>` runs (new `--files` flag) with a live status line (`⚙︎ processing <name> · N queued`)
- Double-processing guarded, including against orphaned pre-restart runs

### Review
- Score-sorted queue, keyboard triage (`s`/`r`/`e`/`k`, `⌘s` stages while editing)
- Inline editor with autosize, per-post draft persistence (localStorage), char count
- Select text → ask-fable span rewrite (uses style guide, strips preamble/quotes), selection stays highlighted via backdrop while prompting
- Stages to Typefully with platform awareness

### Reply
- Scan timeline (background job) → per-tweet cards with suggested reply → edit → post+like or skip (skips persist 24h)

### Stats
- Account tiles, 7d metrics, 90-day goal progress, best hours, top post; 1h cache

### Unfollow
- Candidates ranked by Haiku relevance scores (cached permanently in `.shippost-relevance-cache.json`; scored from bios when available, names/metrics otherwise, auto-rescored when bios arrive)
- Feed-presence protection: accounts seen in the home timeline within 30 days are never suggested (logged during reply scans)
- Quality fixes: 'spammy' requires low followers, new follow-farmer signal
- Whitelist (never suggest again) and a **durable pending ledger**: unfollow decisions persist to disk, survive X monthly-cap 402s, and retry on server start or on demand
- Profile links, checkmark-on-queue UX

### Blog (separate commit)
- Prompt tightened to single-argument 250-450 word essays, no section headers, banned AI-isms; mechanical em-dash strip as backstop

## Notes
- All content generation stays on the configured model (`claude-fable-5`); Haiku is used only for internal metadata (transcript summaries, relevance scores)
- Server is localhost-only, no auth — same trust model as the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)